### PR TITLE
navbar logo wrapper fix

### DIFF
--- a/components/clubsite/Header.tsx
+++ b/components/clubsite/Header.tsx
@@ -6,7 +6,7 @@ import Socials from "@/components/clubsite/Socials";
 const Header = (props: { defaultPage: number }) => {
     return (
         <div className="w-full h-20 sm:px-20 grid grid-cols-2 items-center pt-6 sm:pt-4">
-            <div>
+            <div className="justify-self-start">
                 <a href="/">
                     <Image
                         src={logo}


### PR DESCRIPTION
before you can click anywhere in this box. 
![image](https://github.com/user-attachments/assets/7d6abbf5-3a2b-45f3-bd15-a52b5429ffbe)

made it so you can only click on the logo to be re-directed.