### PR TITLE
[Correlation Testing] Add tests for calculations

### DIFF
--- a/correlation-api/analysis/correlation.py
+++ b/correlation-api/analysis/correlation.py
@@ -13,6 +13,8 @@ def compute_lagged_correlation(series_a: pd.Series, series_b: pd.Series, max_lag
     # Drop the first row if it contains the ticker name (non-numeric)
     def clean_series(s: pd.Series) -> pd.Series:
         s_clean = s.copy()
+        if len(s_clean) == 0:
+            return s_clean
         if not pd.api.types.is_numeric_dtype(s_clean.iloc[0]):
             s_clean = s_clean.iloc[1:]
         s_numeric = pd.to_numeric(s_clean, errors='coerce')

--- a/correlation-api/pytest.ini
+++ b/correlation-api/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+testpaths = tests

--- a/correlation-api/tests/conftest.py
+++ b/correlation-api/tests/conftest.py
@@ -1,0 +1,32 @@
+import pytest
+import pandas as pd
+import numpy as np
+
+
+@pytest.fixture
+def simple_pair_df():
+    """5-row DataFrame mimicking load_pair_data output."""
+    return pd.DataFrame({
+        "Date": pd.date_range("2024-01-01", periods=5, freq="B"),
+        "Close_AAPL": [100.0, 110.0, 105.0, 115.0, 120.0],
+        "Close_MSFT": [50.0, 55.0, 52.0, 58.0, 60.0],
+    })
+
+
+@pytest.fixture
+def constant_series():
+    return pd.Series([5.0, 5.0, 5.0, 5.0, 5.0])
+
+
+@pytest.fixture
+def textbook_series():
+    """Mean=5.0, std(ddof=1)=2.13809."""
+    return pd.Series([2.0, 4.0, 4.0, 4.0, 5.0, 5.0, 7.0, 9.0])
+
+
+@pytest.fixture
+def leader_follower_pair():
+    """b[t] = a[t-1] exactly."""
+    a = pd.Series([1.0, 3.0, 2.0, 5.0, 4.0, 1.0, 3.0, 6.0])
+    b = pd.Series([0.0, 1.0, 3.0, 2.0, 5.0, 4.0, 1.0, 3.0])
+    return a, b

--- a/correlation-api/tests/test_lagged_correlation.py
+++ b/correlation-api/tests/test_lagged_correlation.py
@@ -1,0 +1,149 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from analysis.correlation import compute_lagged_correlation
+
+
+class TestLaggedCorrelationBasic:
+    def test_lag_zero_matches_pearson(self):
+        a = pd.Series([1.0, 2.0, 4.0, 7.0])
+        b = pd.Series([3.0, 5.0, 8.0, 10.0])
+        result = compute_lagged_correlation(a, b, max_lag=0)
+        assert len(result) == 1
+        assert result["Lag"].iloc[0] == 0
+        assert result["Correlation"].iloc[0] == pytest.approx(a.corr(b), abs=1e-6)
+
+    def test_perfectly_correlated_linear(self):
+        """Two linear series: any sub-slice is perfectly correlated."""
+        a = pd.Series([1.0, 2.0, 3.0, 4.0, 5.0])
+        b = pd.Series([10.0, 20.0, 30.0, 40.0, 50.0])
+        result = compute_lagged_correlation(a, b, max_lag=2)
+        for _, row in result.iterrows():
+            assert row["Correlation"] == pytest.approx(1.0, abs=1e-6)
+
+    def test_anticorrelated(self):
+        a = pd.Series([1.0, 2.0, 3.0, 4.0, 5.0])
+        b = pd.Series([5.0, 4.0, 3.0, 2.0, 1.0])
+        result = compute_lagged_correlation(a, b, max_lag=0)
+        assert result["Correlation"].iloc[0] == pytest.approx(-1.0, abs=1e-6)
+
+    def test_leader_follower_peak_at_lag_plus_one(self, leader_follower_pair):
+        """b[t] = a[t-1], so correlation should peak at lag=+1."""
+        a, b = leader_follower_pair
+        result = compute_lagged_correlation(a, b, max_lag=3)
+        corr_dict = dict(zip(result["Lag"], result["Correlation"]))
+        # At lag=+1, shifted_a aligns perfectly with b
+        assert corr_dict[1] == pytest.approx(1.0, abs=1e-6)
+        # The peak should be at lag=+1
+        max_lag = result.loc[result["Correlation"].idxmax(), "Lag"]
+        assert max_lag == 1
+
+    def test_leader_follower_all_values(self, leader_follower_pair):
+        """Verify all 7 lag values against hand-computed Pearson correlations."""
+        a, b = leader_follower_pair
+        result = compute_lagged_correlation(a, b, max_lag=3)
+        corr_dict = dict(zip(result["Lag"], result["Correlation"]))
+
+        # At lag=+1: shifted_a = [NaN,1,3,2,5,4,1,3] corr with b=[0,1,3,2,5,4,1,3]
+        # Effective: a_shifted=[1,3,2,5,4,1,3] vs b=[1,3,2,5,4,1,3] -> corr=1.0
+        assert corr_dict[1] == pytest.approx(1.0, abs=1e-6)
+
+        # At lag=0: direct correlation
+        assert corr_dict[0] == pytest.approx(a.corr(b), abs=1e-6)
+
+        # Verify lag=-1: shift b by 1, so shifted_b = [NaN,0,1,3,2,5,4,1]
+        # Effective: a=[1,3,2,5,4,1,3] vs shifted_b=[0,1,3,2,5,4,1] -> their corr
+        shifted_b = b.shift(1)
+        valid = ~(pd.isna(a) | pd.isna(shifted_b))
+        expected = a[valid].corr(shifted_b[valid])
+        assert corr_dict[-1] == pytest.approx(expected, abs=1e-6)
+
+
+class TestLaggedCorrelationSymmetry:
+    def test_corr_ab_lag_k_equals_corr_ba_lag_neg_k(self, leader_follower_pair):
+        """Fundamental mathematical property: corr(A,B,lag=k) == corr(B,A,lag=-k)."""
+        a, b = leader_follower_pair
+        result_ab = compute_lagged_correlation(a, b, max_lag=3)
+        result_ba = compute_lagged_correlation(b, a, max_lag=3)
+
+        corr_ab = dict(zip(result_ab["Lag"], result_ab["Correlation"]))
+        corr_ba = dict(zip(result_ba["Lag"], result_ba["Correlation"]))
+
+        for k in range(-3, 4):
+            ab_val = corr_ab[k]
+            ba_val = corr_ba[-k]
+            if pd.isna(ab_val) and pd.isna(ba_val):
+                continue
+            assert ab_val == pytest.approx(ba_val, abs=1e-10)
+
+
+class TestLaggedCorrelationOutput:
+    def test_columns(self, leader_follower_pair):
+        a, b = leader_follower_pair
+        result = compute_lagged_correlation(a, b, max_lag=2)
+        assert list(result.columns) == ["Lag", "Correlation"]
+
+    def test_row_count(self, leader_follower_pair):
+        a, b = leader_follower_pair
+        result = compute_lagged_correlation(a, b, max_lag=3)
+        assert len(result) == 7  # 2*3+1
+
+    def test_lags_contiguous(self, leader_follower_pair):
+        a, b = leader_follower_pair
+        result = compute_lagged_correlation(a, b, max_lag=3)
+        assert list(result["Lag"]) == [-3, -2, -1, 0, 1, 2, 3]
+
+    def test_max_lag_zero(self):
+        a = pd.Series([1.0, 2.0, 3.0, 4.0])
+        b = pd.Series([2.0, 4.0, 6.0, 8.0])
+        result = compute_lagged_correlation(a, b, max_lag=0)
+        assert len(result) == 1
+        assert result["Lag"].iloc[0] == 0
+        assert result["Correlation"].iloc[0] == pytest.approx(1.0, abs=1e-6)
+
+
+class TestLaggedCorrelationEdgeCases:
+    def test_constant_series_all_nan(self):
+        """Zero variance -> undefined Pearson -> NaN."""
+        a = pd.Series([5.0, 5.0, 5.0, 5.0, 5.0])
+        b = pd.Series([1.0, 2.0, 3.0, 4.0, 5.0])
+        result = compute_lagged_correlation(a, b, max_lag=2)
+        for _, row in result.iterrows():
+            assert pd.isna(row["Correlation"])
+
+    def test_short_series(self):
+        """2 elements with lag=1: after shift only 1 valid pair -> NaN."""
+        a = pd.Series([1.0, 2.0])
+        b = pd.Series([3.0, 4.0])
+        result = compute_lagged_correlation(a, b, max_lag=1)
+        corr_dict = dict(zip(result["Lag"], result["Correlation"]))
+        # lag=0: 2 points, both linear -> corr=1.0
+        assert corr_dict[0] == pytest.approx(1.0, abs=1e-6)
+        # lag=+-1: only 1 valid point after shift -> NaN
+        assert pd.isna(corr_dict[1])
+        assert pd.isna(corr_dict[-1])
+
+    def test_single_element(self):
+        a = pd.Series([1.0])
+        b = pd.Series([2.0])
+        result = compute_lagged_correlation(a, b, max_lag=1)
+        for _, row in result.iterrows():
+            assert pd.isna(row["Correlation"])
+
+    def test_clean_series_strips_header(self):
+        """Non-numeric first row (e.g. ticker name) is stripped."""
+        a = pd.Series(["AAPL", "100", "200"])
+        b = pd.Series(["MSFT", "50", "100"])
+        result = compute_lagged_correlation(a, b, max_lag=0)
+        # After stripping headers: [100,200] vs [50,100] -> perfectly correlated
+        assert result["Correlation"].iloc[0] == pytest.approx(1.0, abs=1e-6)
+
+    def test_empty_series(self):
+        """Empty series should not crash (after bug fix)."""
+        a = pd.Series([], dtype=float)
+        b = pd.Series([], dtype=float)
+        result = compute_lagged_correlation(a, b, max_lag=1)
+        assert len(result) == 3  # -1, 0, 1
+        for _, row in result.iterrows():
+            assert pd.isna(row["Correlation"])

--- a/correlation-api/tests/test_safe_divisor.py
+++ b/correlation-api/tests/test_safe_divisor.py
@@ -1,0 +1,46 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from analysis.spread import _safe_divisor
+
+
+class TestSafeDivisorScalar:
+    def test_nonzero_passthrough(self):
+        assert _safe_divisor(5.0) == 5.0
+
+    def test_zero_replaced_with_nan(self):
+        assert np.isnan(_safe_divisor(0.0))
+
+    def test_near_zero_below_tolerance(self):
+        assert np.isnan(_safe_divisor(1e-13))
+
+    def test_negative_near_zero_below_tolerance(self):
+        assert np.isnan(_safe_divisor(-1e-13))
+
+    def test_at_tolerance_boundary_kept(self):
+        """Values exactly at the tolerance threshold (1e-12) are kept."""
+        result = _safe_divisor(1e-12)
+        assert result == 1e-12
+
+    def test_nan_input(self):
+        # abs(nan) < tol is False, so nan passes through as-is
+        result = _safe_divisor(np.nan)
+        assert np.isnan(result)
+
+
+class TestSafeDivisorSeries:
+    def test_mixed_values(self):
+        s = pd.Series([1.0, 0.0, 3.0, -1e-13, 5.0])
+        result = _safe_divisor(s)
+        assert result.iloc[0] == 1.0
+        assert np.isnan(result.iloc[1])
+        assert result.iloc[2] == 3.0
+        assert np.isnan(result.iloc[3])
+        assert result.iloc[4] == 5.0
+
+    def test_negative_near_zero_uses_abs(self):
+        s = pd.Series([-1e-13, -1e-11])
+        result = _safe_divisor(s)
+        assert np.isnan(result.iloc[0])
+        assert result.iloc[1] == pytest.approx(-1e-11)

--- a/correlation-api/tests/test_spread_calculations.py
+++ b/correlation-api/tests/test_spread_calculations.py
@@ -1,0 +1,85 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from analysis.spread import (
+    calculate_price_difference_spread,
+    calculate_ratio_spread,
+    calculate_log_ratio_spread,
+)
+
+
+class TestPriceDifferenceSpread:
+    def test_basic(self):
+        a = pd.Series([100.0, 200.0, 150.0])
+        b = pd.Series([90.0, 180.0, 160.0])
+        result = calculate_price_difference_spread(a, b)
+        expected = [10.0, 20.0, -10.0]
+        assert list(result) == expected
+
+    def test_identical_series_gives_zero(self):
+        a = pd.Series([10.0, 20.0, 30.0])
+        result = calculate_price_difference_spread(a, a)
+        assert all(result == 0.0)
+
+
+class TestRatioSpread:
+    def test_basic(self):
+        a = pd.Series([10.0, 20.0, 30.0])
+        b = pd.Series([5.0, 10.0, 15.0])
+        result = calculate_ratio_spread(a, b)
+        assert list(result) == [2.0, 2.0, 2.0]
+
+    def test_division_by_zero_gives_nan(self):
+        a = pd.Series([10.0, 20.0, 30.0])
+        b = pd.Series([5.0, 0.0, 10.0])
+        result = calculate_ratio_spread(a, b)
+        assert result.iloc[0] == 2.0
+        assert np.isnan(result.iloc[1])
+        assert result.iloc[2] == 3.0
+
+    def test_negative_denominator(self):
+        a = pd.Series([10.0, 20.0])
+        b = pd.Series([-5.0, 10.0])
+        result = calculate_ratio_spread(a, b)
+        assert result.iloc[0] == pytest.approx(-2.0)
+        assert result.iloc[1] == pytest.approx(2.0)
+
+
+class TestLogRatioSpread:
+    def test_basic(self):
+        a = pd.Series([10.0, 20.0, 30.0])
+        b = pd.Series([5.0, 10.0, 15.0])
+        result = calculate_log_ratio_spread(a, b)
+        expected = np.log(2.0)
+        for val in result:
+            assert val == pytest.approx(expected, abs=1e-10)
+
+    def test_negative_ratio_becomes_nan(self):
+        a = pd.Series([-1.0, 2.0, 3.0])
+        b = pd.Series([1.0, 1.0, 1.0])
+        result = calculate_log_ratio_spread(a, b)
+        assert np.isnan(result.iloc[0])
+        assert result.iloc[1] == pytest.approx(np.log(2.0))
+        assert result.iloc[2] == pytest.approx(np.log(3.0))
+
+    def test_division_by_zero(self):
+        a = pd.Series([10.0, 20.0])
+        b = pd.Series([0.0, 10.0])
+        result = calculate_log_ratio_spread(a, b)
+        assert np.isnan(result.iloc[0])
+        assert result.iloc[1] == pytest.approx(np.log(2.0))
+
+    def test_ratio_of_one_gives_zero(self):
+        a = pd.Series([5.0, 5.0])
+        b = pd.Series([5.0, 5.0])
+        result = calculate_log_ratio_spread(a, b)
+        for val in result:
+            assert val == pytest.approx(0.0, abs=1e-10)
+
+    def test_preserves_index(self):
+        idx = pd.Index([10, 20, 30])
+        a = pd.Series([100.0, 200.0, 300.0], index=idx)
+        b = pd.Series([50.0, 100.0, 150.0], index=idx)
+        result = calculate_log_ratio_spread(a, b)
+        assert list(result.index) == [10, 20, 30]

--- a/correlation-api/tests/test_spread_metrics.py
+++ b/correlation-api/tests/test_spread_metrics.py
@@ -1,0 +1,94 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from analysis.spread import calculate_spread_metrics
+
+
+class TestSpreadMetricsDifference:
+    def test_values(self, simple_pair_df):
+        """AAPL=[100,110,105,115,120], MSFT=[50,55,52,58,60] -> diff=[50,55,53,57,60]."""
+        result_df, metrics = calculate_spread_metrics(
+            simple_pair_df, "AAPL", "MSFT", spread_type="difference"
+        )
+        expected_spread = [50.0, 55.0, 53.0, 57.0, 60.0]
+        for actual, exp in zip(result_df["spread"].tolist(), expected_spread):
+            assert actual == pytest.approx(exp, abs=1e-6)
+
+        assert metrics["mean"] == pytest.approx(np.mean(expected_spread), abs=1e-4)
+        assert metrics["std"] == pytest.approx(
+            pd.Series(expected_spread).std(), abs=1e-4
+        )
+        assert metrics["min"] == pytest.approx(50.0, abs=1e-4)
+        assert metrics["max"] == pytest.approx(60.0, abs=1e-4)
+        assert metrics["current"] == pytest.approx(60.0, abs=1e-4)
+
+        # current_zscore = (60 - mean) / std
+        mean = np.mean(expected_spread)
+        std = pd.Series(expected_spread).std()
+        assert metrics["current_zscore"] == pytest.approx((60.0 - mean) / std, abs=1e-4)
+
+
+class TestSpreadMetricsRatio:
+    def test_values(self, simple_pair_df):
+        result_df, metrics = calculate_spread_metrics(
+            simple_pair_df, "AAPL", "MSFT", spread_type="ratio"
+        )
+        expected_spread = [100/50, 110/55, 105/52, 115/58, 120/60]
+        for actual, exp in zip(result_df["spread"].tolist(), expected_spread):
+            assert actual == pytest.approx(exp, abs=1e-6)
+
+        assert metrics["current"] == pytest.approx(120.0 / 60.0, abs=1e-4)
+
+
+class TestSpreadMetricsLogRatio:
+    def test_values(self, simple_pair_df):
+        result_df, metrics = calculate_spread_metrics(
+            simple_pair_df, "AAPL", "MSFT", spread_type="log_ratio"
+        )
+        expected_spread = [np.log(100/50), np.log(110/55), np.log(105/52),
+                           np.log(115/58), np.log(120/60)]
+        for actual, exp in zip(result_df["spread"].tolist(), expected_spread):
+            assert actual == pytest.approx(exp, abs=1e-6)
+
+
+class TestSpreadMetricsStructure:
+    def test_result_df_columns(self, simple_pair_df):
+        result_df, _ = calculate_spread_metrics(
+            simple_pair_df, "AAPL", "MSFT", spread_type="difference"
+        )
+        assert list(result_df.columns) == [
+            "Date", "AAPL_price", "MSFT_price", "spread", "zscore"
+        ]
+
+    def test_result_df_length(self, simple_pair_df):
+        result_df, _ = calculate_spread_metrics(
+            simple_pair_df, "AAPL", "MSFT", spread_type="difference"
+        )
+        assert len(result_df) == len(simple_pair_df)
+
+    def test_num_observations(self, simple_pair_df):
+        _, metrics = calculate_spread_metrics(
+            simple_pair_df, "AAPL", "MSFT", spread_type="difference"
+        )
+        assert metrics["num_observations"] == 5
+
+    def test_invalid_spread_type(self, simple_pair_df):
+        with pytest.raises(ValueError, match="Unknown spread_type"):
+            calculate_spread_metrics(
+                simple_pair_df, "AAPL", "MSFT", spread_type="invalid"
+            )
+
+    def test_zero_price_in_log_ratio(self):
+        """Zero price should produce NaN spread, not crash."""
+        df = pd.DataFrame({
+            "Date": pd.date_range("2024-01-01", periods=3, freq="B"),
+            "Close_A": [10.0, 20.0, 30.0],
+            "Close_B": [5.0, 0.0, 10.0],
+        })
+        result_df, metrics = calculate_spread_metrics(df, "A", "B", spread_type="log_ratio")
+        assert not np.isnan(result_df["spread"].iloc[0])
+        assert np.isnan(result_df["spread"].iloc[1])
+        assert not np.isnan(result_df["spread"].iloc[2])
+        # num_observations should exclude the NaN row
+        assert metrics["num_observations"] == 2

--- a/correlation-api/tests/test_zscore.py
+++ b/correlation-api/tests/test_zscore.py
@@ -1,0 +1,105 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from analysis.spread import calculate_zscore
+
+
+class TestZScoreGlobal:
+    def test_textbook_values(self, textbook_series):
+        """[2,4,4,4,5,5,7,9] -> mean=5, std=2.13809 (ddof=1)."""
+        result = calculate_zscore(textbook_series, window=None)
+        mean = 5.0
+        std = textbook_series.std()  # ddof=1 by default
+        expected = [(v - mean) / std for v in textbook_series]
+        for actual, exp in zip(result.tolist(), expected):
+            assert actual == pytest.approx(exp, abs=1e-6)
+
+    def test_mean_of_zscores_is_zero(self, textbook_series):
+        result = calculate_zscore(textbook_series, window=None)
+        assert result.mean() == pytest.approx(0.0, abs=1e-10)
+
+    def test_std_of_zscores_is_one(self, textbook_series):
+        result = calculate_zscore(textbook_series, window=None)
+        assert result.std() == pytest.approx(1.0, abs=1e-10)
+
+    def test_constant_series_all_nan(self, constant_series):
+        """std=0 -> _safe_divisor returns NaN -> all z-scores are NaN."""
+        result = calculate_zscore(constant_series, window=None)
+        assert all(pd.isna(result))
+
+    def test_single_element_nan(self):
+        """std(ddof=1) of a single element is NaN."""
+        result = calculate_zscore(pd.Series([42.0]), window=None)
+        assert all(pd.isna(result))
+
+    def test_two_elements(self):
+        """Smallest valid case: [3,7] -> mean=5, std=2*sqrt(2)/sqrt(1)? No.
+        std(ddof=1) of [3,7] = sqrt(((3-5)^2+(7-5)^2)/1) = sqrt(8) = 2.8284.
+        z = [-0.7071, 0.7071]"""
+        data = pd.Series([3.0, 7.0])
+        result = calculate_zscore(data, window=None)
+        expected = [-1.0 / np.sqrt(2), 1.0 / np.sqrt(2)]
+        for actual, exp in zip(result.tolist(), expected):
+            assert actual == pytest.approx(exp, abs=1e-4)
+
+    def test_with_nan_values(self):
+        """NaN positions stay NaN; valid positions use mean/std of valid data."""
+        data = pd.Series([1.0, np.nan, 3.0, 4.0, 5.0])
+        result = calculate_zscore(data, window=None)
+        # pandas mean/std skip NaN by default
+        valid = data.dropna()
+        mean = valid.mean()  # (1+3+4+5)/4 = 3.25
+        std = valid.std()    # ddof=1
+        assert np.isnan(result.iloc[1])
+        assert result.iloc[0] == pytest.approx((1.0 - mean) / std, abs=1e-6)
+        assert result.iloc[2] == pytest.approx((3.0 - mean) / std, abs=1e-6)
+
+    def test_all_nan(self):
+        result = calculate_zscore(pd.Series([np.nan, np.nan, np.nan]), window=None)
+        assert all(pd.isna(result))
+
+    def test_empty_series(self):
+        result = calculate_zscore(pd.Series([], dtype=float), window=None)
+        assert len(result) == 0
+
+
+class TestZScoreRolling:
+    def test_linear_ramp_all_ones(self):
+        """For [1..10] with window=3, each point is 1 std above rolling mean.
+        window=[k, k+1, k+2]: mean=k+1, std=1 (ddof=1), z=(k+2-(k+1))/1=1.0"""
+        data = pd.Series(range(1, 11), dtype=float)
+        result = calculate_zscore(data, window=3)
+        # First 2 are NaN (not enough data for rolling)
+        assert np.isnan(result.iloc[0])
+        assert np.isnan(result.iloc[1])
+        for i in range(2, 10):
+            assert result.iloc[i] == pytest.approx(1.0, abs=1e-6)
+
+    def test_window_larger_than_series(self):
+        data = pd.Series([1.0, 2.0, 3.0])
+        result = calculate_zscore(data, window=10)
+        assert all(pd.isna(result))
+
+    def test_nonuniform_data(self):
+        """Hand-computed rolling z-scores for [10,12,8,15,11,9,14] window=3."""
+        data = pd.Series([10.0, 12.0, 8.0, 15.0, 11.0, 9.0, 14.0])
+        result = calculate_zscore(data, window=3)
+
+        assert np.isnan(result.iloc[0])
+        assert np.isnan(result.iloc[1])
+
+        # Index 2: window=[10,12,8], mean=10, std=2.0, z=(8-10)/2 = -1.0
+        assert result.iloc[2] == pytest.approx(-1.0, abs=1e-4)
+
+        # Index 3: window=[12,8,15], mean=11.6667, std=3.5119, z=(15-11.6667)/3.5119 = 0.9492
+        assert result.iloc[3] == pytest.approx(0.9492, abs=1e-3)
+
+        # Index 4: window=[8,15,11], mean=11.3333, std=3.5119, z=(11-11.3333)/3.5119 = -0.0950
+        assert result.iloc[4] == pytest.approx(-0.0950, abs=1e-3)
+
+        # Index 5: window=[15,11,9], mean=11.6667, std=3.0551, z=(9-11.6667)/3.0551 = -0.8729
+        assert result.iloc[5] == pytest.approx(-0.8729, abs=1e-3)
+
+        # Index 6: window=[11,9,14], mean=11.3333, std=2.5166, z=(14-11.3333)/2.5166 = 1.0596
+        assert result.iloc[6] == pytest.approx(1.0596, abs=1e-3)


### PR DESCRIPTION
 Calculations verified correct:
  - Z-score normalization (global + rolling) -- textbook values match, statistical properties hold (mean=0, std=1), edge cases (constant series, NaN, empty)
  handled properly
  - Spread calculations -- price difference, ratio, and log ratio all produce correct values, including safe handling of division by zero and negative ratios
  - Spread metrics integration -- mean, std, min, max, current, and current_zscore all verified against hand-computed expected values for all 3 spread types
  - Lagged correlation -- lag=0 matches standard Pearson, leader/follower data correctly peaks at lag=+1, symmetry property corr(A,B,lag=k) == corr(B,A,lag=-k)
  holds, edge cases verified