### PR TITLE
Deploy correlation-api to Render

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,29 @@ clubsite/
 2. Append an entry to the project list in `lib/data.ts`
 3. If it needs a backend, add a sibling directory (e.g. `clubsite/<name>-api/`) and extend `next.config.mjs` with another rewrite rule
 
-## Production notes
+## Deployment
 
-The `/api/*` rewrite targets `http://localhost:5050`, which only works locally. For production, replace the rewrite destination with the deployed API URL (or front the Flask service behind the same domain).
+```
+Browser ──► Netlify (Next.js site)
+                │  /api/* rewrite (next.config.mjs)
+                ▼
+       Render (Flask correlation-api)
+                │
+                ▼
+         Yahoo Finance
+```
+
+- **Frontend** deploys to Netlify from `main` (current site: `watstreet.netlify.app`).
+- **Backend** deploys to Render from `main` via `render.yaml`. The service builds from `correlation-api/`, installs `requirements.txt`, and runs `gunicorn`.
+- The rewrite destination is parameterised: `next.config.mjs` reads `CORRELATION_API_URL` and falls back to `http://localhost:5050` for local dev.
+
+### First-time setup
+
+1. **Render** — In the Render dashboard, create a new Blueprint from this repo. It picks up `render.yaml` and provisions the `correlation-api` service automatically. Copy the resulting URL (e.g. `https://correlation-api-xxxx.onrender.com`).
+2. **Netlify** — Add an environment variable `CORRELATION_API_URL` set to the Render URL above, then trigger a redeploy. The Next rewrite now proxies `/api/*` to Render.
+
+### Notes
+
+- Render's free tier spins down after 15 min of inactivity. First request after a cold start takes ~30s.
+- After any change to `correlation-api/`, Render auto-redeploys on push to `main`.
+- The `/api/*` rewrite is server-side (Netlify proxies to Render), so the browser only ever sees the Netlify domain — no CORS gymnastics needed.

--- a/correlation-api/requirements.txt
+++ b/correlation-api/requirements.txt
@@ -1,5 +1,6 @@
 flask>=3.0.0
 flask-cors>=4.0.0
+gunicorn>=21.0.0
 yfinance>=0.2.40
 pandas>=2.0.0
 numpy>=1.24.0

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,10 +1,12 @@
 /** @type {import('next').NextConfig} */
+const apiBase = process.env.CORRELATION_API_URL || "http://localhost:5050";
+
 const nextConfig = {
   async rewrites() {
     return [
       {
         source: "/api/:path*",
-        destination: "http://localhost:5050/api/:path*",
+        destination: `${apiBase}/api/:path*`,
       },
     ];
   },

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,11 @@
+services:
+  - type: web
+    name: correlation-api
+    runtime: python
+    rootDir: correlation-api
+    plan: free
+    buildCommand: pip install -r requirements.txt
+    startCommand: gunicorn --bind 0.0.0.0:$PORT --workers 1 --timeout 90 app:app
+    envVars:
+      - key: PYTHON_VERSION
+        value: 3.12.0


### PR DESCRIPTION
## Summary

Wires up production hosting for the Flask backend so the Netlify deploy can actually load data.

- `render.yaml` provisions the `correlation-api` web service on Render's free tier (gunicorn, Python 3.12, single worker, 90s timeout)
- `correlation-api/requirements.txt` gains `gunicorn` for production
- `next.config.mjs` reads `CORRELATION_API_URL` and falls back to `http://localhost:5050` — local dev is unchanged
- README's deployment section updated with the chain: Netlify → Render → yfinance

## After merging

1. **Render dashboard** → New → Blueprint → connect this repo → it picks up `render.yaml` and provisions `correlation-api`. Copy the resulting URL.
2. **Netlify dashboard** → site settings → environment variables → add `CORRELATION_API_URL` = the Render URL → trigger redeploy.

After that, `watstreet.netlify.app/correlation-trading` loads data through Render.

## Test plan

- [x] Local dev still works (env var unset → falls back to localhost:5050)
- [ ] Render provisions cleanly from blueprint
- [ ] Netlify env var set, redeploy succeeds
- [ ] Pair selector loads on `watstreet.netlify.app/correlation-trading`