### PR TITLE
[Correlation Trading] Add correlation breakdown detector

### DIFF
--- a/app/correlation-trading/page.tsx
+++ b/app/correlation-trading/page.tsx
@@ -12,10 +12,12 @@ import SpreadAnalysisCharts from "@/components/correlation/SpreadAnalysisCharts"
 import MetricsPanel from "@/components/correlation/MetricsPanel";
 import SpreadHistogram from "@/components/correlation/SpreadHistogram";
 import Toast from "@/components/correlation/Toast";
+import RiskWarningBanner from "@/components/correlation/RiskWarningBanner";
 
 import type {
   PairInfo,
   CorrelationResponse,
+  RiskBreakdownResponse,
   SpreadResponse,
   SignalLevel,
 } from "@/lib/correlationTypes";
@@ -39,6 +41,7 @@ export default function CorrelationTradingPage() {
   const [loading, setLoading] = useState(false);
   const [corrData, setCorrData] = useState<CorrelationResponse | null>(null);
   const [spreadData, setSpreadData] = useState<SpreadResponse | null>(null);
+  const [riskData, setRiskData] = useState<RiskBreakdownResponse | null>(null);
   const [pairSignals, setPairSignals] = useState<Record<string, SignalLevel>>({});
   const [error, setError] = useState<string | null>(null);
   const [toast, setToast] = useState<{ message: string; type: "error" | "success" } | null>(null);
@@ -49,14 +52,18 @@ export default function CorrelationTradingPage() {
       setError(null);
       setCorrData(null);
       setSpreadData(null);
+      setRiskData(null);
 
       try {
-        const [corrRes, spreadRes] = await Promise.all([
+        const [corrRes, spreadRes, riskRes] = await Promise.all([
           fetch(
             `${API_BASE}/correlation?ticker_a=${pair.ticker_a}&ticker_b=${pair.ticker_b}&start=${dateRange.start}&end=${dateRange.end}`
           ),
           fetch(
             `${API_BASE}/spread?ticker_a=${pair.ticker_a}&ticker_b=${pair.ticker_b}&start=${dateRange.start}&end=${dateRange.end}&spread_type=${spreadType}`
+          ),
+          fetch(
+            `${API_BASE}/risk/breakdown?ticker_a=${pair.ticker_a}&ticker_b=${pair.ticker_b}&start=${dateRange.start}&end=${dateRange.end}`
           ),
         ]);
 
@@ -73,9 +80,13 @@ export default function CorrelationTradingPage() {
 
         const corr: CorrelationResponse = await corrRes.json();
         const spread: SpreadResponse = await spreadRes.json();
+        const risk: RiskBreakdownResponse | null = riskRes.ok
+          ? await riskRes.json()
+          : null;
 
         setCorrData(corr);
         setSpreadData(spread);
+        setRiskData(risk);
 
         setPairSignals((prev) => ({
           ...prev,
@@ -132,6 +143,7 @@ export default function CorrelationTradingPage() {
     setSelectedPair(null);
     setCorrData(null);
     setSpreadData(null);
+    setRiskData(null);
     setError(null);
   };
 
@@ -197,6 +209,8 @@ export default function CorrelationTradingPage() {
 
               {spreadData && (
                 <div className="mt-6 space-y-6">
+                  {riskData?.broken && <RiskWarningBanner risk={riskData} />}
+
                   <MetricsPanel metrics={spreadData.metrics} />
 
                   {corrData && (

--- a/app/correlation-trading/page.tsx
+++ b/app/correlation-trading/page.tsx
@@ -63,7 +63,7 @@ export default function CorrelationTradingPage() {
             `${API_BASE}/spread?ticker_a=${pair.ticker_a}&ticker_b=${pair.ticker_b}&start=${dateRange.start}&end=${dateRange.end}&spread_type=${spreadType}`
           ),
           fetch(
-            `${API_BASE}/risk/breakdown?ticker_a=${pair.ticker_a}&ticker_b=${pair.ticker_b}&start=${dateRange.start}&end=${dateRange.end}`
+            `${API_BASE}/risk/breakdown?ticker_a=${pair.ticker_a}&ticker_b=${pair.ticker_b}&end=${dateRange.end}`
           ),
         ]);
 

--- a/components/correlation/RiskWarningBanner.tsx
+++ b/components/correlation/RiskWarningBanner.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { AlertTriangle } from "lucide-react";
+
+import type { RiskBreakdownResponse } from "@/lib/correlationTypes";
+
+interface RiskWarningBannerProps {
+  risk: RiskBreakdownResponse;
+}
+
+function formatCorrelation(value: number | null): string {
+  return value === null ? "N/A" : value.toFixed(3);
+}
+
+export default function RiskWarningBanner({ risk }: RiskWarningBannerProps) {
+  return (
+    <div className="rounded-xl border border-amber-500/25 bg-amber-500/[0.08] px-4 py-3">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-start gap-3">
+          <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0 text-amber-400" />
+          <div>
+            <p className="text-sm font-semibold text-amber-100">
+              Correlation breakdown detected for {risk.ticker_a}/{risk.ticker_b}
+            </p>
+            <p className="mt-1 text-xs text-amber-100/70">
+              Recent 60d correlation is below the historical baseline.
+              {risk.broken_since ? ` Broken since ${risk.broken_since}.` : ""}
+            </p>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3 text-xs">
+          <span className="font-mono tabular-nums text-amber-100">
+            Current {formatCorrelation(risk.current_corr)}
+          </span>
+          <span className="font-mono tabular-nums text-amber-100/70">
+            Baseline {formatCorrelation(risk.baseline_corr)}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/correlation-api/README.md
+++ b/correlation-api/README.md
@@ -24,7 +24,7 @@ The Next dev server (`npm run dev` in the repo root) rewrites browser requests f
 | GET | `/api/validate` | `ticker` | `{valid, ticker, name}` — used to validate custom ticker input |
 | GET | `/api/correlation` | `ticker_a`, `ticker_b`, `start`, `end`, `max_lag` | Lagged Pearson correlation across `[-max_lag, +max_lag]` |
 | GET | `/api/spread` | `ticker_a`, `ticker_b`, `start`, `end`, `spread_type` | Spread series, z-score, and metrics for the pair |
-| GET | `/api/risk/breakdown` | `ticker_a`, `ticker_b`, optional `start`, `end` | Correlation-breakdown risk signal with current 60d correlation, 1y baseline, and `broken_since` |
+| GET | `/api/risk/breakdown` | `ticker_a`, `ticker_b`, optional `end`, optional `start` override | Correlation-breakdown risk signal with its own lookback window, current 60d correlation, 1y baseline, and `broken_since` |
 
 Dates are `YYYY-MM-DD`. `spread_type` is one of the values supported by `analysis/spread.py` (default `log_ratio`).
 

--- a/correlation-api/README.md
+++ b/correlation-api/README.md
@@ -24,6 +24,7 @@ The Next dev server (`npm run dev` in the repo root) rewrites browser requests f
 | GET | `/api/validate` | `ticker` | `{valid, ticker, name}` — used to validate custom ticker input |
 | GET | `/api/correlation` | `ticker_a`, `ticker_b`, `start`, `end`, `max_lag` | Lagged Pearson correlation across `[-max_lag, +max_lag]` |
 | GET | `/api/spread` | `ticker_a`, `ticker_b`, `start`, `end`, `spread_type` | Spread series, z-score, and metrics for the pair |
+| GET | `/api/risk/breakdown` | `ticker_a`, `ticker_b`, optional `start`, `end` | Correlation-breakdown risk signal with current 60d correlation, 1y baseline, and `broken_since` |
 
 Dates are `YYYY-MM-DD`. `spread_type` is one of the values supported by `analysis/spread.py` (default `log_ratio`).
 

--- a/correlation-api/analysis/correlation.py
+++ b/correlation-api/analysis/correlation.py
@@ -1,5 +1,8 @@
 import pandas as pd
 
+from analysis.util import clean_series
+
+
 def compute_lagged_correlation(series_a: pd.Series, series_b: pd.Series, max_lag: int) -> pd.DataFrame:
     """
     Compute lagged correlation between two series.
@@ -10,16 +13,6 @@ def compute_lagged_correlation(series_a: pd.Series, series_b: pd.Series, max_lag
     Returns:
         pd.DataFrame: DataFrame with columns 'Lag' and 'Correlation'.
     """
-    # Drop the first row if it contains the ticker name (non-numeric)
-    def clean_series(s: pd.Series) -> pd.Series:
-        s_clean = s.copy()
-        if not pd.api.types.is_numeric_dtype(s_clean.iloc[0]):
-            s_clean = s_clean.iloc[1:]
-        s_numeric = pd.to_numeric(s_clean, errors='coerce')
-        if not isinstance(s_numeric, pd.Series):
-            s_numeric = pd.Series(s_numeric, index=s_clean.index)
-        return s_numeric
-
     series_a = clean_series(series_a)
     series_b = clean_series(series_b)
 

--- a/correlation-api/analysis/risk.py
+++ b/correlation-api/analysis/risk.py
@@ -1,0 +1,105 @@
+from typing import Optional
+
+import pandas as pd
+
+
+ABSOLUTE_CORRELATION_FLOOR = 0.5
+MIN_BASELINE_OBSERVATIONS = 60
+
+
+def _clean_series(series: pd.Series) -> pd.Series:
+    cleaned = pd.to_numeric(series.copy(), errors="coerce")
+    if not isinstance(cleaned, pd.Series):
+        cleaned = pd.Series(cleaned, index=series.index)
+    return cleaned
+
+
+def _iso_date(index_value) -> str:
+    parsed = pd.to_datetime(index_value, errors="coerce")
+    if not pd.isna(parsed):
+        return parsed.date().isoformat()
+    return str(index_value)
+
+
+def _safe_current(series: pd.Series) -> Optional[float]:
+    if series.empty or pd.isna(series.iloc[-1]):
+        return None
+    return float(series.iloc[-1])
+
+
+def detect_correlation_breakdown(
+    series_a: pd.Series,
+    series_b: pd.Series,
+    recent_window: int = 60,
+    baseline_window: int = 252,
+    threshold: float = 0.5,
+) -> dict:
+    """
+    Detect whether a pair's recent rolling correlation has broken down.
+
+    The detector compares the latest recent-window correlation with the
+    trailing baseline mean of those recent-window correlations. The baseline is
+    shifted by one row so the current correlation does not dilute its own
+    comparison point.
+    """
+    if recent_window < 2:
+        raise ValueError("recent_window must be at least 2")
+    if baseline_window < 1:
+        raise ValueError("baseline_window must be at least 1")
+    if threshold <= 0:
+        raise ValueError("threshold must be positive")
+
+    aligned = pd.concat(
+        [_clean_series(series_a).rename("a"), _clean_series(series_b).rename("b")],
+        axis=1,
+        join="inner",
+    ).dropna()
+
+    if len(aligned) < recent_window + 1:
+        return {
+            "current_corr": None,
+            "baseline_corr": None,
+            "broken": False,
+            "broken_since": None,
+        }
+
+    rolling_corr = aligned["a"].rolling(window=recent_window).corr(aligned["b"])
+    min_baseline_periods = min(baseline_window, MIN_BASELINE_OBSERVATIONS)
+    baseline_corr = (
+        rolling_corr.shift(1)
+        .rolling(window=baseline_window, min_periods=min_baseline_periods)
+        .mean()
+    )
+
+    current_corr = _safe_current(rolling_corr)
+    current_baseline = _safe_current(baseline_corr)
+
+    valid_comparison = rolling_corr.notna() & baseline_corr.notna()
+    broken_points = valid_comparison & (
+        (rolling_corr < baseline_corr * threshold)
+        | (rolling_corr < ABSOLUTE_CORRELATION_FLOOR)
+    )
+
+    broken = bool(broken_points.iloc[-1]) if not broken_points.empty else False
+    broken_since = None
+
+    if broken:
+        current_run = broken_points[broken_points].index
+        last_index = broken_points.index[-1]
+
+        for idx in reversed(broken_points.index):
+            if idx == last_index and not broken_points.loc[idx]:
+                break
+            if not broken_points.loc[idx]:
+                break
+            broken_since = idx
+
+        if broken_since is None and len(current_run) > 0:
+            broken_since = current_run[-1]
+
+    return {
+        "current_corr": current_corr,
+        "baseline_corr": current_baseline,
+        "broken": broken,
+        "broken_since": _iso_date(broken_since) if broken_since is not None else None,
+    }

--- a/correlation-api/analysis/risk.py
+++ b/correlation-api/analysis/risk.py
@@ -2,17 +2,12 @@ from typing import Optional
 
 import pandas as pd
 
+from analysis.util import clean_series
+
 
 ABSOLUTE_CORRELATION_FLOOR = 0.5
 MIN_BASELINE_OBSERVATIONS = 60
 MIN_POSITIVE_BASELINE_CORRELATION = 0.1
-
-
-def _clean_series(series: pd.Series) -> pd.Series:
-    cleaned = pd.to_numeric(series.copy(), errors="coerce")
-    if not isinstance(cleaned, pd.Series):
-        cleaned = pd.Series(cleaned, index=series.index)
-    return cleaned
 
 
 def _iso_date(index_value) -> str:
@@ -52,7 +47,7 @@ def detect_correlation_breakdown(
         raise ValueError("threshold must be positive")
 
     aligned = pd.concat(
-        [_clean_series(series_a).rename("a"), _clean_series(series_b).rename("b")],
+        [clean_series(series_a).rename("a"), clean_series(series_b).rename("b")],
         axis=1,
         join="inner",
     ).dropna()

--- a/correlation-api/analysis/risk.py
+++ b/correlation-api/analysis/risk.py
@@ -5,6 +5,7 @@ import pandas as pd
 
 ABSOLUTE_CORRELATION_FLOOR = 0.5
 MIN_BASELINE_OBSERVATIONS = 60
+MIN_POSITIVE_BASELINE_CORRELATION = 0.1
 
 
 def _clean_series(series: pd.Series) -> pd.Series:
@@ -40,7 +41,8 @@ def detect_correlation_breakdown(
     The detector compares the latest recent-window correlation with the
     trailing baseline mean of those recent-window correlations. The baseline is
     shifted by one row so the current correlation does not dilute its own
-    comparison point.
+    comparison point. It only evaluates breakdowns when the baseline indicates
+    an established positive relationship.
     """
     if recent_window < 2:
         raise ValueError("recent_window must be at least 2")
@@ -75,9 +77,13 @@ def detect_correlation_breakdown(
     current_baseline = _safe_current(baseline_corr)
 
     valid_comparison = rolling_corr.notna() & baseline_corr.notna()
-    broken_points = valid_comparison & (
-        (rolling_corr < baseline_corr * threshold)
-        | (rolling_corr < ABSOLUTE_CORRELATION_FLOOR)
+    positive_baseline = baseline_corr > MIN_POSITIVE_BASELINE_CORRELATION
+    relative_breakdown = rolling_corr < baseline_corr * threshold
+    absolute_breakdown = rolling_corr < ABSOLUTE_CORRELATION_FLOOR
+    broken_points = (
+        valid_comparison
+        & positive_baseline
+        & (relative_breakdown | absolute_breakdown)
     )
 
     broken = bool(broken_points.iloc[-1]) if not broken_points.empty else False

--- a/correlation-api/analysis/util.py
+++ b/correlation-api/analysis/util.py
@@ -1,0 +1,12 @@
+import pandas as pd
+
+
+def clean_series(series: pd.Series) -> pd.Series:
+    cleaned = series.copy()
+    if not cleaned.empty and not pd.api.types.is_numeric_dtype(cleaned.iloc[0]):
+        cleaned = cleaned.iloc[1:]
+
+    numeric = pd.to_numeric(cleaned, errors="coerce")
+    if not isinstance(numeric, pd.Series):
+        numeric = pd.Series(numeric, index=cleaned.index)
+    return numeric

--- a/correlation-api/app.py
+++ b/correlation-api/app.py
@@ -1,6 +1,6 @@
 import os
 import math
-from datetime import date
+from datetime import date, datetime, timedelta
 from flask import Flask, request, jsonify
 from flask_cors import CORS
 import pandas as pd
@@ -14,6 +14,8 @@ from analysis.risk import detect_correlation_breakdown
 
 app = Flask(__name__)
 CORS(app)
+
+RISK_LOOKBACK_DAYS = 540
 
 PAIRS = [
     {"ticker_a": "MSFT",  "ticker_b": "GOOGL", "name_a": "Microsoft",         "name_b": "Google",            "sector": "Technology"},
@@ -43,6 +45,14 @@ def _safe_float(val):
         return v
     except (TypeError, ValueError):
         return None
+
+
+def _risk_start_date(end_date):
+    try:
+        parsed_end = datetime.strptime(end_date, "%Y-%m-%d").date()
+    except ValueError as exc:
+        raise ValueError("end must be in YYYY-MM-DD format") from exc
+    return (parsed_end - timedelta(days=RISK_LOOKBACK_DAYS)).isoformat()
 
 
 @app.route("/api/pairs", methods=["GET"])
@@ -144,13 +154,13 @@ def get_spread():
 def get_risk_breakdown():
     ticker_a = request.args.get("ticker_a", "").upper()
     ticker_b = request.args.get("ticker_b", "").upper()
-    start = request.args.get("start", "2015-01-01")
     end = request.args.get("end", str(date.today()))
 
     if not ticker_a or not ticker_b:
         return jsonify({"error": "ticker_a and ticker_b are required"}), 400
 
     try:
+        start = request.args.get("start") or _risk_start_date(end)
         df = load_pair_data(ticker_a, ticker_b, start, end)
         date_index = pd.to_datetime(df["Date"])
         series_a = pd.Series(df[f"Close_{ticker_a}"].values, index=date_index)
@@ -165,6 +175,8 @@ def get_risk_breakdown():
             "broken": bool(breakdown["broken"]),
             "broken_since": breakdown["broken_since"],
         })
+    except ValueError as e:
+        return jsonify({"error": str(e)}), 400
     except Exception as e:
         return jsonify({"error": str(e)}), 500
 

--- a/correlation-api/app.py
+++ b/correlation-api/app.py
@@ -10,6 +10,7 @@ import yfinance as yf
 from analysis.data_loader import load_pair_data
 from analysis.correlation import compute_lagged_correlation
 from analysis.spread import calculate_spread_metrics
+from analysis.risk import detect_correlation_breakdown
 
 app = Flask(__name__)
 CORS(app)
@@ -134,6 +135,35 @@ def get_spread():
             "spread_type": spread_type,
             "data": data,
             "metrics": clean_metrics,
+        })
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+@app.route("/api/risk/breakdown", methods=["GET"])
+def get_risk_breakdown():
+    ticker_a = request.args.get("ticker_a", "").upper()
+    ticker_b = request.args.get("ticker_b", "").upper()
+    start = request.args.get("start", "2015-01-01")
+    end = request.args.get("end", str(date.today()))
+
+    if not ticker_a or not ticker_b:
+        return jsonify({"error": "ticker_a and ticker_b are required"}), 400
+
+    try:
+        df = load_pair_data(ticker_a, ticker_b, start, end)
+        date_index = pd.to_datetime(df["Date"])
+        series_a = pd.Series(df[f"Close_{ticker_a}"].values, index=date_index)
+        series_b = pd.Series(df[f"Close_{ticker_b}"].values, index=date_index)
+        breakdown = detect_correlation_breakdown(series_a, series_b)
+
+        return jsonify({
+            "ticker_a": ticker_a,
+            "ticker_b": ticker_b,
+            "current_corr": _safe_float(breakdown["current_corr"]),
+            "baseline_corr": _safe_float(breakdown["baseline_corr"]),
+            "broken": bool(breakdown["broken"]),
+            "broken_since": breakdown["broken_since"],
         })
     except Exception as e:
         return jsonify({"error": str(e)}), 500

--- a/lib/correlationTypes.ts
+++ b/lib/correlationTypes.ts
@@ -48,6 +48,15 @@ export interface SpreadResponse {
   metrics: SpreadMetrics;
 }
 
+export interface RiskBreakdownResponse {
+  ticker_a: string;
+  ticker_b: string;
+  current_corr: number | null;
+  baseline_corr: number | null;
+  broken: boolean;
+  broken_since: string | null;
+}
+
 export type SignalLevel = "normal" | "watch" | "signal";
 export type SignalDirection = "long" | "short" | "hold";
 


### PR DESCRIPTION
## Background

Pairs trading assumes two tickers keep moving together. Issue #9 adds a risk check for cases where that relationship has recently weakened, so the page can warn users before they rely on a stale historical pair relationship.

Closes #9.

## Summary

- Added a backend correlation-breakdown detector that compares the latest 60-day rolling correlation against a 1-year baseline.
- Added `GET /api/risk/breakdown` for pair-level risk results.
- Decoupled the risk endpoint's lookback window from the chart's selected display range.
- Added frontend typing and a warning banner above the metrics panel when a selected pair is currently broken.
- Documented the new API endpoint in the correlation API README.

## How to run and see the banner locally

1. Start the Flask API:
   ```bash
   cd correlation-api
   python3 app.py
   ```

2. In another terminal, start the Next app:
   ```bash
   npm install
   npm run dev
   ```

3. Open `http://localhost:3000/correlation-trading`.

4. Select `GE / BA`, then choose `5Y`.

5. The warning banner should appear above the metrics panel.

If `GE / BA` does not show the banner on `3Y`, clear the bad local cache file and refresh:

```bash
rm correlation-api/data/raw/BA_2023-05-29_to_2026-05-29_raw.csv
```

<img width="1161" height="668" alt="Screenshot 2026-05-29 at 6 22 34 PM" src="https://github.com/user-attachments/assets/1766f484-b6e6-4473-a9a8-7d8f6a6725d6" />

## Test plan

- Ran Python compile check for the Flask app and analysis modules.
- Ran a synthetic detector check where the relationship intentionally breaks and verified `broken: true`.
- Ran a stable inverse-correlation check and verified it does not get labeled as a positive-pair breakdown.
- Verified the risk route computes its own lookback start when only `end` is provided.
- Verified invalid `end` values return a JSON 400 from the risk route.
- Verified the new endpoint returns `broken: true` for `GE/BA` over a recent multi-year window.
- Ran `npm run build` successfully.
- Checked the dev page at `http://localhost:3000/correlation-trading` and verified the `/api/risk/breakdown` rewrite works.

Note: `npm run lint` currently fails before checking files because `next lint` is passing removed options to ESLint 9 (`useEslintrc`, `extensions`, etc.). This appears to be existing tooling config drift rather than an issue with this PR.
