### PR TITLE
feat: add sector screener endpoint GET /api/screener

### DIFF
--- a/correlation-api/analysis/screener.py
+++ b/correlation-api/analysis/screener.py
@@ -1,0 +1,111 @@
+"""
+correlation-api/analysis/screener.py
+
+Screens a sector's tickers for correlated pairs above a minimum threshold.
+Uses log returns (not raw prices) for correlation — more stationary and
+comparable across different price scales.
+
+Step 1 of pair discovery. Cointegration filter (Khush's) is step 2.
+"""
+
+import itertools
+import pandas as pd
+import numpy as np
+from analysis.data_loader import get_stock_data
+
+# ---------------------------------------------------------------------------
+# Sector universes — hardcoded to start, extend as follow-up tasks land
+# ---------------------------------------------------------------------------
+
+SECTOR_TICKERS: dict[str, list[str]] = {
+    "technology": [
+        "AAPL", "MSFT", "GOOGL", "META", "NVDA",
+        "AMD",  "INTC", "AVGO", "QCOM", "TXN",
+        "ORCL", "CRM",  "ADBE", "NOW",  "SNOW",
+    ],
+}
+
+
+def _load_returns(tickers: list[str], start: str, end: str) -> pd.DataFrame:
+    """
+    Fetch closing prices for all tickers and compute daily log returns.
+
+    Returns a DataFrame indexed by Date with one column per ticker.
+    Tickers that fail to load are silently dropped with a warning so a
+    single bad symbol doesn't abort the whole screen.
+    """
+    frames: dict[str, pd.Series] = {}
+
+    for ticker in tickers:
+        try:
+            df = get_stock_data(ticker, start, end, cache=True)
+            prices = pd.to_numeric(df.set_index("Date")["Close"], errors="coerce").dropna()
+            if prices.empty:
+                print(f"[screener] Warning: no price data for {ticker}, skipping.")
+                continue
+            # Log returns: ln(P_t / P_{t-1})
+            log_ret = np.log(prices / prices.shift(1)).dropna()
+            frames[ticker] = log_ret
+        except Exception as exc:
+            print(f"[screener] Warning: could not load {ticker} — {exc}")
+
+    if not frames:
+        return pd.DataFrame()
+
+    # Inner join so every column has the same date range
+    returns = pd.DataFrame(frames).dropna()
+    return returns
+
+
+def screen_sector(
+    tickers: list[str],
+    start: str,
+    end: str,
+    min_corr: float = 0.85,
+) -> list[dict]:
+    """
+    Find all pairs in `tickers` whose log-return Pearson correlation
+    is at or above `min_corr` over [start, end].
+
+    Args:
+        tickers:  List of ticker symbols to screen.
+        start:    Start date string, e.g. "2024-01-01".
+        end:      End date string,   e.g. "2025-01-01".
+        min_corr: Minimum absolute correlation to include (default 0.85).
+
+    Returns:
+        List of dicts sorted descending by correlation:
+            [{"ticker_a": str, "ticker_b": str, "correlation": float}, ...]
+    """
+    if len(tickers) < 2:
+        raise ValueError("Need at least 2 tickers to screen.")
+    if not (0.0 <= min_corr <= 1.0):
+        raise ValueError(f"min_corr must be in [0, 1], got {min_corr}.")
+
+    print(f"[screener] Loading returns for {len(tickers)} tickers ({start} → {end})...")
+    returns = _load_returns(tickers, start, end)
+
+    if returns.shape[1] < 2:
+        return []
+
+    print(f"[screener] Computing pairwise correlations across {returns.shape[1]} tickers "
+          f"({returns.shape[0]} trading days)...")
+
+    corr_matrix = returns.corr(method="pearson")
+    loaded_tickers = list(returns.columns)
+
+    results: list[dict] = []
+    for ticker_a, ticker_b in itertools.combinations(loaded_tickers, 2):
+        corr = float(corr_matrix.loc[ticker_a, ticker_b])
+        if np.isnan(corr):
+            continue
+        if abs(corr) >= min_corr:
+            results.append({
+                "ticker_a":    ticker_a,
+                "ticker_b":    ticker_b,
+                "correlation": round(corr, 6),
+            })
+
+    results.sort(key=lambda x: x["correlation"], reverse=True)
+    print(f"[screener] Found {len(results)} pairs with |corr| ≥ {min_corr}.")
+    return results

--- a/correlation-api/analysis/screener.py
+++ b/correlation-api/analysis/screener.py
@@ -23,6 +23,21 @@ SECTOR_TICKERS: dict[str, list[str]] = {
         "AMD",  "INTC", "AVGO", "QCOM", "TXN",
         "ORCL", "CRM",  "ADBE", "NOW",  "SNOW",
     ],
+    "healthcare": [
+        "JNJ", "UNH", "PFE", "MRK", "ABT",
+        "TMO", "DHR", "BMY", "AMGN", "LLY",
+        "MDT", "ISRG", "VRTX", "IQV", "MTD",
+    ],
+    "financials": [
+        "JPM", "BAC", "WFC", "GS", "MS",
+        "BLK", "SCHW", "AXP", "BK", "PNC",
+        "USB", "TFC", "FITB", "COF", "MTB",
+    ],
+    "energy": [
+        "XOM", "CVX", "COP", "EOG", "SLB",
+        "MPC", "PSX", "VLO", "WMB", "EPD",
+        "OKE", "KMI", "HAL", "BKR", "DVN",
+    ],
 }
 
 

--- a/correlation-api/analysis/screener.py
+++ b/correlation-api/analysis/screener.py
@@ -52,8 +52,9 @@ def _load_returns(tickers: list[str], start: str, end: str) -> pd.DataFrame:
     if not frames:
         return pd.DataFrame()
 
-    # Inner join so every column has the same date range
-    returns = pd.DataFrame(frames)
+    # Inner join on Date — dropna() keeps only rows present across all tickers
+    # so every pair is measured over the same common window
+    returns = pd.DataFrame(frames).dropna()
     return returns
 
 

--- a/correlation-api/analysis/screener.py
+++ b/correlation-api/analysis/screener.py
@@ -53,7 +53,7 @@ def _load_returns(tickers: list[str], start: str, end: str) -> pd.DataFrame:
         return pd.DataFrame()
 
     # Inner join so every column has the same date range
-    returns = pd.DataFrame(frames).dropna()
+    returns = pd.DataFrame(frames)
     return returns
 
 
@@ -99,7 +99,7 @@ def screen_sector(
         corr = float(corr_matrix.loc[ticker_a, ticker_b])
         if np.isnan(corr):
             continue
-        if abs(corr) >= min_corr:
+        if corr >= min_corr:
             results.append({
                 "ticker_a":    ticker_a,
                 "ticker_b":    ticker_b,

--- a/correlation-api/app.py
+++ b/correlation-api/app.py
@@ -10,6 +10,7 @@ import yfinance as yf
 from analysis.data_loader import load_pair_data
 from analysis.correlation import compute_lagged_correlation
 from analysis.spread import calculate_spread_metrics
+from analysis.screener import screen_sector, SECTOR_TICKERS
 
 app = Flask(__name__)
 CORS(app)
@@ -137,7 +138,29 @@ def get_spread():
         })
     except Exception as e:
         return jsonify({"error": str(e)}), 500
+    
+@app.route("/api/screener", methods=["GET"])
+def get_screener():
+    sector = request.args.get("sector", "").lower().strip()
+    if not sector:
+        return jsonify({"error": "Missing required param: sector"}), 400
+    if sector not in SECTOR_TICKERS:
+        return jsonify({"error": f"Unknown sector '{sector}'.", "available_sectors": sorted(SECTOR_TICKERS.keys())}), 400
 
+    try:
+        min_corr = float(request.args.get("min_corr", 0.70))
+    except ValueError:
+        return jsonify({"error": "min_corr must be a float between 0 and 1."}), 400
+
+    start = request.args.get("start", "2024-01-01")
+    end = request.args.get("end", str(date.today()))
+
+    try:
+        pairs = screen_sector(SECTOR_TICKERS[sector], start, end, min_corr=min_corr)
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+    return jsonify({"sector": sector, "min_corr": min_corr, "pairs": pairs})
 
 if __name__ == "__main__":
     port = int(os.environ.get("CORRELATION_API_PORT", 5050))

--- a/correlation-api/app.py
+++ b/correlation-api/app.py
@@ -146,11 +146,12 @@ def get_screener():
         return jsonify({"error": "Missing required param: sector"}), 400
     if sector not in SECTOR_TICKERS:
         return jsonify({"error": f"Unknown sector '{sector}'.", "available_sectors": sorted(SECTOR_TICKERS.keys())}), 400
-
     try:
         min_corr = float(request.args.get("min_corr", 0.70))
     except ValueError:
         return jsonify({"error": "min_corr must be a float between 0 and 1."}), 400
+    if not (0.0 <= min_corr <= 1.0):
+        return jsonify({"error": "min_corr must be between 0.0 and 1.0."}), 400
 
     start = request.args.get("start", "2024-01-01")
     end = request.args.get("end", str(date.today()))

--- a/correlation-api/app.py
+++ b/correlation-api/app.py
@@ -16,22 +16,31 @@ app = Flask(__name__)
 CORS(app)
 
 PAIRS = [
-    {"ticker_a": "MSFT",  "ticker_b": "GOOGL", "name_a": "Microsoft",         "name_b": "Google",            "sector": "Technology"},
-    {"ticker_a": "AMD",   "ticker_b": "NVDA",  "name_a": "AMD",               "name_b": "NVIDIA",            "sector": "Technology"},
-    {"ticker_a": "CVS",   "ticker_b": "JNJ",   "name_a": "CVS Health",        "name_b": "Johnson & Johnson", "sector": "Healthcare"},
-    {"ticker_a": "PFE",   "ticker_b": "MRK",   "name_a": "Pfizer",            "name_b": "Merck",             "sector": "Healthcare"},
-    {"ticker_a": "CL",    "ticker_b": "KMB",   "name_a": "Colgate-Palmolive", "name_b": "Kimberly-Clark",    "sector": "Consumer"},
-    {"ticker_a": "KO",    "ticker_b": "PEP",   "name_a": "Coca-Cola",         "name_b": "PepsiCo",           "sector": "Consumer"},
-    {"ticker_a": "COST",  "ticker_b": "BJ",    "name_a": "Costco",            "name_b": "BJ's Wholesale",    "sector": "Consumer"},
-    {"ticker_a": "GE",    "ticker_b": "BA",    "name_a": "GE Aerospace",      "name_b": "Boeing",            "sector": "Industrials"},
-    {"ticker_a": "V",     "ticker_b": "MA",    "name_a": "Visa",              "name_b": "Mastercard",        "sector": "Financials"},
-    {"ticker_a": "MS",    "ticker_b": "GS",    "name_a": "Morgan Stanley",    "name_b": "Goldman Sachs",     "sector": "Financials"},
-    {"ticker_a": "JPM",   "ticker_b": "BAC",   "name_a": "JPMorgan Chase",    "name_b": "Bank of America",   "sector": "Financials"},
-    {"ticker_a": "XOM",   "ticker_b": "CVX",   "name_a": "ExxonMobil",        "name_b": "Chevron",           "sector": "Energy"},
-    {"ticker_a": "T",     "ticker_b": "VZ",    "name_a": "AT&T",              "name_b": "Verizon",           "sector": "Telecom"},
-    {"ticker_a": "WMT",   "ticker_b": "TGT",   "name_a": "Walmart",           "name_b": "Target",            "sector": "Retail"},
-]
+    # Technology
+    # (no pairs passed cointegration in tech sector, 2020-present window)
 
+    # Healthcare
+    {"ticker_a": "DHR",  "ticker_b": "IQV",  "name_a": "Danaher",                "name_b": "IQVIA Holdings",          "sector": "Healthcare"},
+    {"ticker_a": "TMO",  "ticker_b": "MTD",  "name_a": "Thermo Fisher Scientific","name_b": "Mettler-Toledo",          "sector": "Healthcare"},
+    {"ticker_a": "TMO",  "ticker_b": "IQV",  "name_a": "Thermo Fisher Scientific","name_b": "IQVIA Holdings",          "sector": "Healthcare"},
+    {"ticker_a": "IQV",  "ticker_b": "MTD",  "name_a": "IQVIA Holdings",          "name_b": "Mettler-Toledo",          "sector": "Healthcare"},
+
+    # Financials
+    {"ticker_a": "BLK",  "ticker_b": "COF",  "name_a": "BlackRock",               "name_b": "Capital One",             "sector": "Financials"},
+    {"ticker_a": "WFC",  "ticker_b": "AXP",  "name_a": "Wells Fargo",             "name_b": "American Express",        "sector": "Financials"},
+    {"ticker_a": "PNC",  "ticker_b": "FITB", "name_a": "PNC Financial",           "name_b": "Fifth Third Bancorp",     "sector": "Financials"},
+    {"ticker_a": "GS",   "ticker_b": "BK",   "name_a": "Goldman Sachs",           "name_b": "Bank of New York Mellon", "sector": "Financials"},
+    {"ticker_a": "MS",   "ticker_b": "BK",   "name_a": "Morgan Stanley",          "name_b": "Bank of New York Mellon", "sector": "Financials"},
+    {"ticker_a": "SCHW", "ticker_b": "MTB",  "name_a": "Charles Schwab",          "name_b": "M&T Bank",                "sector": "Financials"},
+
+    # Energy
+    {"ticker_a": "MPC",  "ticker_b": "PSX",  "name_a": "Marathon Petroleum",      "name_b": "Phillips 66",             "sector": "Energy"},
+    {"ticker_a": "EPD",  "ticker_b": "BKR",  "name_a": "Enterprise Products",     "name_b": "Baker Hughes",            "sector": "Energy"},
+    {"ticker_a": "WMB",  "ticker_b": "KMI",  "name_a": "Williams Companies",      "name_b": "Kinder Morgan",           "sector": "Energy"},
+    {"ticker_a": "WMB",  "ticker_b": "EPD",  "name_a": "Williams Companies",      "name_b": "Enterprise Products",     "sector": "Energy"},
+    {"ticker_a": "COP",  "ticker_b": "SLB",  "name_a": "ConocoPhillips",          "name_b": "SLB",                     "sector": "Energy"},
+    {"ticker_a": "MPC",  "ticker_b": "EPD",  "name_a": "Marathon Petroleum",      "name_b": "Enterprise Products",     "sector": "Energy"},
+]
 
 def _safe_float(val):
     try:

--- a/correlation-api/curate_pairs.py
+++ b/correlation-api/curate_pairs.py
@@ -1,0 +1,63 @@
+from datetime import datetime
+import pandas as pd
+from statsmodels.tsa.stattools import coint
+from analysis.data_loader import load_pair_data
+from analysis.screener import screen_sector, SECTOR_TICKERS
+
+START = "2020-01-01"
+END = datetime.today().strftime("%Y-%m-%d")
+MIN_CORR = 0.60
+MAX_P_VALUE = 0.05
+
+
+def test_cointegration(ticker_a, ticker_b):
+    try:
+        df = load_pair_data(ticker_a, ticker_b, START, END, cache=True)
+        series_a = pd.to_numeric(df[f"Close_{ticker_a}"].squeeze(), errors="coerce").dropna()
+        series_b = pd.to_numeric(df[f"Close_{ticker_b}"].squeeze(), errors="coerce").dropna()
+        series_a, series_b = series_a.align(series_b, join="inner")
+        if len(series_a) < 30:
+            return None
+        _, p_value, _ = coint(series_a, series_b)
+        return round(float(p_value), 4)
+    except Exception as e:
+        print(f"  [error] {ticker_a}/{ticker_b}: {e}")
+        return None
+
+
+all_candidates = []
+
+for sector, tickers in SECTOR_TICKERS.items():
+    print(f"Screening {sector} ({len(tickers)} tickers)")
+
+    corr_pairs = screen_sector(tickers, START, END, min_corr=MIN_CORR)
+    print(f"Found {len(corr_pairs)} correlated pairs, running cointegration")
+
+    for pair in corr_pairs:
+        a, b = pair["ticker_a"], pair["ticker_b"]
+        print(f"  Testing {a}/{b} (corr={pair['correlation']:.3f})", end=" ", flush=True)
+        p = test_cointegration(a, b)
+        if p is None:
+            print("skipped")
+            continue
+        status = "PASS" if p < MAX_P_VALUE else "FAIL"
+        print(f"p={p:.4f} {status}")
+        all_candidates.append({
+            "ticker_a": a,
+            "ticker_b": b,
+            "sector": sector,
+            "correlation": pair["correlation"],
+            "p_value": p,
+            "cointegrated": p < MAX_P_VALUE,
+        })
+
+validated = [c for c in all_candidates if c["cointegrated"]]
+validated.sort(key=lambda x: x["p_value"])
+
+print(f"VALIDATED PAIRS (p < {MAX_P_VALUE})")
+print(f"{'Pair':<15} {'Sector':<15} {'Corr':>6} {'p-value':>8}")
+for v in validated:
+    pair_str = f"{v['ticker_a']}/{v['ticker_b']}"
+    print(f"{pair_str:<15} {v['sector']:<15} {v['correlation']:>6.3f} {v['p_value']:>8.4f}")
+
+print(f"\nTotal validated: {len(validated)} / {len(all_candidates)} tested")

--- a/correlation-api/curate_pairs.py
+++ b/correlation-api/curate_pairs.py
@@ -9,6 +9,24 @@ END = datetime.today().strftime("%Y-%m-%d")
 MIN_CORR = 0.60
 MAX_P_VALUE = 0.05
 
+# Step 1 — existing 14 pairs to validate first
+EXISTING_PAIRS = [
+    ("MSFT", "GOOGL", "Technology"),
+    ("AMD",  "NVDA",  "Technology"),
+    ("CVS",  "JNJ",   "Healthcare"),
+    ("PFE",  "MRK",   "Healthcare"),
+    ("CL",   "KMB",   "Consumer"),
+    ("KO",   "PEP",   "Consumer"),
+    ("COST", "BJ",    "Consumer"),
+    ("GE",   "BA",    "Industrials"),
+    ("V",    "MA",    "Financials"),
+    ("MS",   "GS",    "Financials"),
+    ("JPM",  "BAC",   "Financials"),
+    ("XOM",  "CVX",   "Energy"),
+    ("T",    "VZ",    "Telecom"),
+    ("WMT",  "TGT",   "Retail"),
+]
+
 
 def test_cointegration(ticker_a, ticker_b):
     try:
@@ -25,16 +43,49 @@ def test_cointegration(ticker_a, ticker_b):
         return None
 
 
-all_candidates = []
+# -----------------------------------------------------------------------
+# Step 1 — run cointegration on existing 14 pairs, drop ones with p > 0.05
+# -----------------------------------------------------------------------
+print("STEP 1 — Validating existing 14 pairs")
+
+kept = []
+cut = []
+
+for ticker_a, ticker_b, sector in EXISTING_PAIRS:
+    print(f"  Testing {ticker_a}/{ticker_b}", end=" ", flush=True)
+    p = test_cointegration(ticker_a, ticker_b)
+    if p is None:
+        print("skipped")
+        continue
+    status = "KEEP" if p < MAX_P_VALUE else "CUT"
+    print(f"p={p:.4f} {status}")
+    entry = {"ticker_a": ticker_a, "ticker_b": ticker_b, "sector": sector, "p_value": p}
+    if p < MAX_P_VALUE:
+        kept.append(entry)
+    else:
+        cut.append(entry)
+
+print(f"\nKept: {len(kept)} / Cut: {len(cut)}")
+
+# -----------------------------------------------------------------------
+# Step 2 — run screener across sectors, cointegration test on candidates
+# -----------------------------------------------------------------------
+print("STEP 2 — Screener across sectors for new candidates")
+
+screener_validated = []
+existing_pair_keys = {(a, b) for a, b, _ in EXISTING_PAIRS} | {(b, a) for a, b, _ in EXISTING_PAIRS}
 
 for sector, tickers in SECTOR_TICKERS.items():
-    print(f"Screening {sector} ({len(tickers)} tickers)")
-
     corr_pairs = screen_sector(tickers, START, END, min_corr=MIN_CORR)
-    print(f"Found {len(corr_pairs)} correlated pairs, running cointegration")
+    print(f"Found {len(corr_pairs)} correlated pairs")
 
     for pair in corr_pairs:
         a, b = pair["ticker_a"], pair["ticker_b"]
+
+        # skip if already in existing pairs
+        if (a, b) in existing_pair_keys:
+            continue
+
         print(f"  Testing {a}/{b} (corr={pair['correlation']:.3f})", end=" ", flush=True)
         p = test_cointegration(a, b)
         if p is None:
@@ -42,22 +93,37 @@ for sector, tickers in SECTOR_TICKERS.items():
             continue
         status = "PASS" if p < MAX_P_VALUE else "FAIL"
         print(f"p={p:.4f} {status}")
-        all_candidates.append({
-            "ticker_a": a,
-            "ticker_b": b,
-            "sector": sector,
-            "correlation": pair["correlation"],
-            "p_value": p,
-            "cointegrated": p < MAX_P_VALUE,
-        })
+        if p < MAX_P_VALUE:
+            screener_validated.append({
+                "ticker_a": a,
+                "ticker_b": b,
+                "sector": sector,
+                "correlation": pair["correlation"],
+                "p_value": p,
+            })
 
-validated = [c for c in all_candidates if c["cointegrated"]]
-validated.sort(key=lambda x: x["p_value"])
+# -----------------------------------------------------------------------
+# Step 3 — combine and de-dupe
+# -----------------------------------------------------------------------
+all_validated = kept + screener_validated
 
-print(f"VALIDATED PAIRS (p < {MAX_P_VALUE})")
-print(f"{'Pair':<15} {'Sector':<15} {'Corr':>6} {'p-value':>8}")
-for v in validated:
+# de-dupe by pair key
+seen = set()
+final = []
+for v in all_validated:
+    key = tuple(sorted([v["ticker_a"], v["ticker_b"]]))
+    if key not in seen:
+        seen.add(key)
+        final.append(v)
+
+final.sort(key=lambda x: x["p_value"])
+
+print(f"FINAL VALIDATED PAIRS (p < {MAX_P_VALUE}, {START} to {END})")
+print(f"{'Pair':<15} {'Sector':<15} {'p-value':>8}")
+for v in final:
     pair_str = f"{v['ticker_a']}/{v['ticker_b']}"
-    print(f"{pair_str:<15} {v['sector']:<15} {v['correlation']:>6.3f} {v['p_value']:>8.4f}")
+    print(f"{pair_str:<15} {v['sector']:<15} {v['p_value']:>8.4f}")
 
-print(f"\nTotal validated: {len(validated)} / {len(all_candidates)} tested")
+print(f"\nTotal final pairs: {len(final)}")
+print(f"  From existing list: {len(kept)}")
+print(f"  New from screener:  {len(screener_validated)}")

--- a/correlation-api/tests/test_screener.py
+++ b/correlation-api/tests/test_screener.py
@@ -1,0 +1,56 @@
+import pytest
+import pandas as pd
+import numpy as np
+from unittest.mock import patch
+from analysis.screener import screen_sector, _load_returns
+
+# Minimal mock price data — 5 days, 2 tickers moving together
+def make_mock_df(ticker, prices):
+    return pd.DataFrame({
+        "Date": ["2024-01-01", "2024-01-02", "2024-01-03", "2024-01-04", "2024-01-05"],
+        "Close": prices,
+        "Ticker": ticker
+    })
+
+@patch("analysis.screener.get_stock_data")
+def test_screen_sector_returns_correlated_pair(mock_get):
+    # AAPL and MSFT move identically — should have correlation ~1.0
+    mock_get.side_effect = lambda ticker, start, end, cache: (
+        make_mock_df("AAPL", [100, 101, 102, 103, 104]) if ticker == "AAPL"
+        else make_mock_df("MSFT", [200, 202, 204, 206, 208])
+    )
+    results = screen_sector(["AAPL", "MSFT"], "2024-01-01", "2024-01-05", min_corr=0.90)
+    assert len(results) == 1
+    assert results[0]["ticker_a"] == "AAPL"
+    assert results[0]["ticker_b"] == "MSFT"
+    assert results[0]["correlation"] >= 0.90
+
+@patch("analysis.screener.get_stock_data")
+def test_screen_sector_filters_low_correlation(mock_get):
+    # AAPL trends up, MSFT moves randomly — low positive correlation, should be excluded
+    mock_get.side_effect = lambda ticker, start, end, cache: (
+        make_mock_df("AAPL", [100, 101, 102, 103, 104]) if ticker == "AAPL"
+        else make_mock_df("MSFT", [200, 210, 195, 215, 200])
+    )
+    results = screen_sector(["AAPL", "MSFT"], "2024-01-01", "2024-01-05", min_corr=0.85)
+    assert len(results) == 0
+
+@patch("analysis.screener.get_stock_data")
+def test_screen_sector_sorted_descending(mock_get):
+    # Three tickers — verify output is sorted highest correlation first
+    mock_get.side_effect = lambda ticker, start, end, cache: {
+        "AAPL": make_mock_df("AAPL", [100, 101, 102, 103, 104]),
+        "MSFT": make_mock_df("MSFT", [200, 202, 204, 206, 208]),
+        "GOOG": make_mock_df("GOOG", [300, 301, 303, 302, 304]),
+    }[ticker]
+    results = screen_sector(["AAPL", "MSFT", "GOOG"], "2024-01-01", "2024-01-05", min_corr=0.50)
+    correlations = [r["correlation"] for r in results]
+    assert correlations == sorted(correlations, reverse=True)
+
+def test_screen_sector_raises_on_too_few_tickers():
+    with pytest.raises(ValueError):
+        screen_sector(["AAPL"], "2024-01-01", "2024-01-05")
+
+def test_screen_sector_raises_on_invalid_min_corr():
+    with pytest.raises(ValueError):
+        screen_sector(["AAPL", "MSFT"], "2024-01-01", "2024-01-05", min_corr=1.5)


### PR DESCRIPTION
## Changes
- Added `correlation-api/analysis/screener.py` with `screen_sector()` function
- Added `GET /api/screener?sector=technology&min_corr=0.85` endpoint to `app.py`

## Issue #10 — Pair Curation

### Step 1 — Existing 14 pairs: all failed cointegration (p < 0.05)
| Pair       | Sector      | p-value | Status |
|------------|-------------|---------|--------|
| MSFT/GOOGL | Technology  | 0.9117  | CUT    |
| AMD/NVDA   | Technology  | 0.7038  | CUT    |
| CVS/JNJ    | Healthcare  | 0.4765  | CUT    |
| PFE/MRK    | Healthcare  | 0.7994  | CUT    |
| CL/KMB     | Consumer    | 0.3294  | CUT    |
| KO/PEP     | Consumer    | 0.9863  | CUT    |
| COST/BJ    | Consumer    | 0.3962  | CUT    |
| GE/BA      | Industrials | 0.9939  | CUT (GE spinoff 2024) |
| V/MA       | Financials  | 0.1096  | CUT    |
| MS/GS      | Financials  | 0.1754  | CUT    |
| JPM/BAC    | Financials  | 0.6839  | CUT    |
| XOM/CVX    | Energy      | 0.3145  | CUT    |
| T/VZ       | Telecom     | 0.5790  | CUT    |
| WMT/TGT    | Retail      | 0.8526  | CUT    |

### Step 2 — Screener across 4 sectors, 213 pairs tested, 16 passed
| Pair     | Sector     | p-value |
|----------|------------|---------|
| MPC/PSX  | Energy     | 0.0002  |
| EPD/BKR  | Energy     | 0.0004  |
| BLK/COF  | Financials | 0.0005  |
| DHR/IQV  | Healthcare | 0.0012  |
| WFC/AXP  | Financials | 0.0015  |
| PNC/FITB | Financials | 0.0027  |
| WMB/KMI  | Energy     | 0.0030  |
| GS/BK    | Financials | 0.0034  |
| WMB/EPD  | Energy     | 0.0035  |
| TMO/MTD  | Healthcare | 0.0086  |
| TMO/IQV  | Healthcare | 0.0091  |
| COP/SLB  | Energy     | 0.0243  |
| MS/BK    | Financials | 0.0257  |
| MPC/EPD  | Energy     | 0.0270  |
| SCHW/MTB | Financials | 0.0328  |
| IQV/MTD  | Healthcare | 0.0402  |

Methodology: curate_pairs.py validates existing pairs first, then runs screener across healthcare, financials, energy, and technology at min_corr=0.60, cointegration tested on each candidate (2020-01-01 to 2026-07-09). No technology pairs passed. 0 original pairs kept. 16 new pairs added.