### PR TITLE
[Correlation Testing] Backtest Harness

### DIFF
--- a/correlation-api/analysis/backtest.py
+++ b/correlation-api/analysis/backtest.py
@@ -100,7 +100,7 @@ def run_backtest(
     daily_dollar_pnl = held_positions * daily_spread_diff
     
     # Daily percentage return relative to gross exposure of the previous day
-    prev_exposure = gross_exposure.shift(1).bfill().fillna(
+    prev_exposure = gross_exposure.shift(1).fillna(
         gross_exposure.iloc[0] if len(gross_exposure) else 1.0)
     daily_returns = daily_dollar_pnl / prev_exposure
     
@@ -145,8 +145,7 @@ def run_backtest(
             if current_pos != 0:
                 exit_idx = i
 
-                ent_hold_idx = min(entry_idx + 1, n - 1)
-                ent_date = sigs.index[ent_hold_idx]
+                ent_date = sigs.index[entry_idx]
                 ex_date = sigs.index[exit_idx]
                 
                 ent_price_a = float(p_a.iloc[entry_idx])
@@ -189,8 +188,7 @@ def run_backtest(
     # Handle open trade at the end of the series
     if current_pos != 0 and n > 0:
         exit_idx = n - 1
-        ent_hold_idx = min(entry_idx + 1, n - 1)
-        ent_date = sigs.index[ent_hold_idx]
+        ent_date = sigs.index[entry_idx]
         ex_date = sigs.index[exit_idx]
         
         ent_price_a = float(p_a.iloc[entry_idx])

--- a/correlation-api/analysis/backtest.py
+++ b/correlation-api/analysis/backtest.py
@@ -1,0 +1,238 @@
+import pandas as pd
+import numpy as np
+from typing import Dict, Any, List, Tuple
+
+def generate_zscore_signals(
+    spread: pd.Series,
+    window: int = 20,
+    entry_z: float = 2.0,
+    exit_z: float = 0.0
+) -> Tuple[pd.Series, pd.Series]:
+    """
+    Generate walk-forward signals from a spread using rolling z-score.
+    
+    Returns:
+        Tuple of (signals, zscore)
+    """
+    mean = spread.rolling(window=window).mean()
+    std = spread.rolling(window=window).std()
+    
+    # Avoid division by zero
+    std = std.where(std >= 1e-12, np.nan)
+    std = std.ffill().fillna(1e-6)
+    
+    zscore = (spread - mean) / std
+    
+    signals = pd.Series(0, index=spread.index)
+    current_pos = 0
+    
+    for i in range(len(spread)):
+        z = zscore.iloc[i]
+        if pd.isna(z):
+            signals.iloc[i] = 0
+            continue
+            
+        if current_pos == 0:
+            if z <= -entry_z:
+                current_pos = 1
+            elif z >= entry_z:
+                current_pos = -1
+        elif current_pos == 1:
+            if z >= -exit_z or z >= 0.0:
+                current_pos = 0
+        elif current_pos == -1:
+            if z <= exit_z or z <= 0.0:
+                current_pos = 0
+                
+        signals.iloc[i] = current_pos
+        
+    return signals, zscore
+
+def run_backtest(
+    prices_a: pd.Series,
+    prices_b: pd.Series,
+    signals: pd.Series,
+    hedge_ratio: float = 1.0
+) -> Dict[str, Any]:
+    """
+    Run a walk-forward pairs trading backtest.
+    
+    Args:
+        prices_a: pd.Series of asset A prices, indexed by Date
+        prices_b: pd.Series of asset B prices, indexed by Date
+        signals: pd.Series of trading signals (+1 = Long Spread, -1 = Short Spread, 0 = Flat), indexed by Date
+        hedge_ratio: hedge ratio to determine the spread (spread = price_a - hedge_ratio * price_b)
+        
+    Returns:
+        A dictionary containing backtest performance metrics:
+        - equity_curve: list of dicts with {"date": str, "value": float}
+        - sharpe: float (annualized Sharpe ratio)
+        - max_dd: float (maximum drawdown as a positive percentage)
+        - num_trades: int
+        - win_rate: float
+        - trade_log: list of dicts with detailed trade info
+    """
+    # Ensure indexes are aligned and sorted chronologically
+    common_idx = prices_a.index.intersection(prices_b.index).intersection(signals.index).sort_values()
+    
+    p_a = prices_a.loc[common_idx]
+    p_b = prices_b.loc[common_idx]
+    sigs = signals.loc[common_idx]
+    
+    # Calculate daily price changes
+    dp_a = p_a.diff().fillna(0.0)
+    dp_b = p_b.diff().fillna(0.0)
+    
+    # Calculate spread
+    spread = p_a - hedge_ratio * p_b
+    
+    # Capital base is the gross exposure at the start of the daily holding period
+    # Capital = price_a + hedge_ratio * price_b
+    # Prevent division by zero
+    gross_exposure = p_a + hedge_ratio * p_b
+    gross_exposure = gross_exposure.replace(0.0, np.nan).ffill().fillna(1.0)
+    
+    # Position held during day t is decided by signal at day t-1
+    held_positions = sigs.shift(1).fillna(0.0)
+    
+    # Daily P&L of holding 1 unit of spread
+    # Long spread (+1) means long A, short B. Short spread (-1) means short A, long B.
+    daily_spread_diff = dp_a - hedge_ratio * dp_b
+    daily_dollar_pnl = held_positions * daily_spread_diff
+    
+    # Daily percentage return relative to gross exposure of the previous day
+    prev_exposure = gross_exposure.shift(1).bfill().fillna(1.0)
+    daily_returns = daily_dollar_pnl / prev_exposure
+    
+    # Calculate cumulative returns (equity curve)
+    cum_returns = daily_returns.cumsum()
+    
+    # Construct equity curve series
+    equity_curve = []
+    for date_val, val in cum_returns.items():
+        date_str = str(date_val.date()) if hasattr(date_val, "date") else str(date_val)
+        equity_curve.append({
+            "date": date_str,
+            "value": float(val)
+        })
+        
+    # Calculate Sharpe Ratio (annualized, assuming risk-free rate of 0)
+    mean_ret = daily_returns.mean()
+    std_ret = daily_returns.std(ddof=1)
+    if std_ret > 1e-6:
+        sharpe = float(np.sqrt(252) * (mean_ret / std_ret))
+    else:
+        sharpe = 0.0
+        
+    # Calculate Maximum Drawdown
+    # peak-to-trough drop
+    running_max = cum_returns.cummax()
+    drawdown = running_max - cum_returns
+    max_dd = float(drawdown.max())
+    
+    # Identify trades and populate trade log
+    trade_log = []
+    current_pos = 0
+    entry_idx = -1
+    
+    n = len(sigs)
+    for i in range(n):
+        sig = int(sigs.iloc[i])
+        
+        # Position transition
+        if sig != current_pos:
+            # If we were in a position, close it
+            if current_pos != 0:
+                exit_idx = i
+                # Calculate trade returns
+                ent_date = sigs.index[entry_idx]
+                ex_date = sigs.index[exit_idx]
+                
+                ent_price_a = float(p_a.iloc[entry_idx])
+                ent_price_b = float(p_b.iloc[entry_idx])
+                ex_price_a = float(p_a.iloc[exit_idx])
+                ex_price_b = float(p_b.iloc[exit_idx])
+                
+                ent_spread = float(spread.iloc[entry_idx])
+                ex_spread = float(spread.iloc[exit_idx])
+                
+                ent_exposure = ent_price_a + hedge_ratio * ent_price_b
+                if ent_exposure == 0:
+                    ent_exposure = 1.0
+                    
+                # Long spread P&L: spread_exit - spread_entry
+                # Short spread P&L: spread_entry - spread_exit
+                pnl_val = (ex_spread - ent_spread) if current_pos == 1 else (ent_spread - ex_spread)
+                pnl_pct = pnl_val / ent_exposure
+                
+                trade_log.append({
+                    "type": "LONG" if current_pos == 1 else "SHORT",
+                    "entry_date": str(ent_date.date()) if hasattr(ent_date, "date") else str(ent_date),
+                    "exit_date": str(ex_date.date()) if hasattr(ex_date, "date") else str(ex_date),
+                    "entry_price_a": ent_price_a,
+                    "entry_price_b": ent_price_b,
+                    "exit_price_a": ex_price_a,
+                    "exit_price_b": ex_price_b,
+                    "entry_spread": ent_spread,
+                    "exit_spread": ex_spread,
+                    "pnl_val": float(pnl_val),
+                    "pnl_pct": float(pnl_pct),
+                    "holding_period": int(exit_idx - entry_idx)
+                })
+                
+            # If new position is non-zero, open it
+            if sig != 0:
+                entry_idx = i
+            current_pos = sig
+            
+    # Handle open trade at the end of the series
+    if current_pos != 0 and n > 0:
+        exit_idx = n - 1
+        ent_date = sigs.index[entry_idx]
+        ex_date = sigs.index[exit_idx]
+        
+        ent_price_a = float(p_a.iloc[entry_idx])
+        ent_price_b = float(p_b.iloc[entry_idx])
+        ex_price_a = float(p_a.iloc[exit_idx])
+        ex_price_b = float(p_b.iloc[exit_idx])
+        
+        ent_spread = float(spread.iloc[entry_idx])
+        ex_spread = float(spread.iloc[exit_idx])
+        
+        ent_exposure = ent_price_a + hedge_ratio * ent_price_b
+        if ent_exposure == 0:
+            ent_exposure = 1.0
+            
+        pnl_val = (ex_spread - ent_spread) if current_pos == 1 else (ent_spread - ex_spread)
+        pnl_pct = pnl_val / ent_exposure
+        
+        trade_log.append({
+            "type": "LONG" if current_pos == 1 else "SHORT",
+            "entry_date": str(ent_date.date()) if hasattr(ent_date, "date") else str(ent_date),
+            "exit_date": str(ex_date.date()) if hasattr(ex_date, "date") else str(ex_date),
+            "entry_price_a": ent_price_a,
+            "entry_price_b": ent_price_b,
+            "exit_price_a": ex_price_a,
+            "exit_price_b": ex_price_b,
+            "entry_spread": ent_spread,
+            "exit_spread": ex_spread,
+            "pnl_val": float(pnl_val),
+            "pnl_pct": float(pnl_pct),
+            "holding_period": int(exit_idx - entry_idx)
+        })
+        
+    num_trades = len(trade_log)
+    if num_trades > 0:
+        profitable_trades = sum(1 for t in trade_log if t["pnl_val"] > 0)
+        win_rate = float(profitable_trades / num_trades)
+    else:
+        win_rate = 0.0
+        
+    return {
+        "equity_curve": equity_curve,
+        "sharpe": sharpe,
+        "max_dd": max_dd,
+        "num_trades": num_trades,
+        "win_rate": win_rate,
+        "trade_log": trade_log
+    }

--- a/correlation-api/analysis/backtest.py
+++ b/correlation-api/analysis/backtest.py
@@ -83,7 +83,6 @@ def run_backtest(
     dp_a = p_a.diff().fillna(0.0)
     dp_b = p_b.diff().fillna(0.0)
     
-    # Calculate spread
     spread = p_a - hedge_ratio * p_b
     
     # Capital base is the gross exposure at the start of the daily holding period
@@ -105,7 +104,7 @@ def run_backtest(
     daily_returns = daily_dollar_pnl / prev_exposure
     
     # Calculate cumulative returns (equity curve)
-    cum_returns = daily_returns.cumsum()
+    cum_returns = daily_returns.cumsum() # guys.
     
     # Construct equity curve series
     equity_curve = []
@@ -130,7 +129,6 @@ def run_backtest(
     drawdown = running_max - cum_returns
     max_dd = float(drawdown.max())
     
-    # Identify trades and populate trade log
     trade_log = []
     current_pos = 0
     entry_idx = -1
@@ -144,7 +142,7 @@ def run_backtest(
             # If we were in a position, close it
             if current_pos != 0:
                 exit_idx = i
-                # Calculate trade returns
+
                 ent_date = sigs.index[entry_idx]
                 ex_date = sigs.index[exit_idx]
                 

--- a/correlation-api/analysis/backtest.py
+++ b/correlation-api/analysis/backtest.py
@@ -105,11 +105,11 @@ def run_backtest(
     daily_returns = daily_dollar_pnl / prev_exposure
     
     # Calculate cumulative returns (equity curve)
-    cum_returns = (1.0 + daily_returns).cumprod().sub(1.0) # guys.
+    cumulative_returns = (1.0 + daily_returns).cumprod().sub(1.0)
     
     # Construct equity curve series
     equity_curve = []
-    for date_val, val in cum_returns.items():
+    for date_val, val in cumulative_returns.items():
         date_str = str(date_val.date()) if hasattr(date_val, "date") else str(date_val)
         equity_curve.append({
             "date": date_str,
@@ -126,7 +126,7 @@ def run_backtest(
         
     # Calculate Maximum Drawdown
     # peak-to-trough drop (as a fraction of equity (positive))
-    equity = 1.0 + cum_returns
+    equity = 1.0 + cumulative_returns
     running_max = equity.cummax()
     drawdown = 1.0 - (equity / running_max)
     max_dd = float(drawdown.max())

--- a/correlation-api/analysis/backtest.py
+++ b/correlation-api/analysis/backtest.py
@@ -1,6 +1,6 @@
 import pandas as pd
 import numpy as np
-from typing import Dict, Any, List, Tuple
+from typing import Dict, Any, Tuple
 
 def generate_zscore_signals(
     spread: pd.Series,
@@ -38,10 +38,10 @@ def generate_zscore_signals(
             elif z >= entry_z:
                 current_pos = -1
         elif current_pos == 1:
-            if z >= -exit_z or z >= 0.0:
+            if z >= -exit_z:
                 current_pos = 0
         elif current_pos == -1:
-            if z <= exit_z or z <= 0.0:
+            if z <= exit_z:
                 current_pos = 0
                 
         signals.iloc[i] = current_pos
@@ -100,11 +100,12 @@ def run_backtest(
     daily_dollar_pnl = held_positions * daily_spread_diff
     
     # Daily percentage return relative to gross exposure of the previous day
-    prev_exposure = gross_exposure.shift(1).bfill().fillna(1.0)
+    prev_exposure = gross_exposure.shift(1).bfill().fillna(
+        gross_exposure.iloc[0] if len(gross_exposure) else 1.0)
     daily_returns = daily_dollar_pnl / prev_exposure
     
     # Calculate cumulative returns (equity curve)
-    cum_returns = daily_returns.cumsum() # guys.
+    cum_returns = (1.0 + daily_returns).cumprod().sub(1.0) # guys.
     
     # Construct equity curve series
     equity_curve = []
@@ -124,9 +125,10 @@ def run_backtest(
         sharpe = 0.0
         
     # Calculate Maximum Drawdown
-    # peak-to-trough drop
-    running_max = cum_returns.cummax()
-    drawdown = running_max - cum_returns
+    # peak-to-trough drop (as a fraction of equity (positive))
+    equity = 1.0 + cum_returns
+    running_max = equity.cummax()
+    drawdown = 1.0 - (equity / running_max)
     max_dd = float(drawdown.max())
     
     trade_log = []
@@ -143,7 +145,8 @@ def run_backtest(
             if current_pos != 0:
                 exit_idx = i
 
-                ent_date = sigs.index[entry_idx]
+                ent_hold_idx = min(entry_idx + 1, n - 1)
+                ent_date = sigs.index[ent_hold_idx]
                 ex_date = sigs.index[exit_idx]
                 
                 ent_price_a = float(p_a.iloc[entry_idx])
@@ -186,7 +189,8 @@ def run_backtest(
     # Handle open trade at the end of the series
     if current_pos != 0 and n > 0:
         exit_idx = n - 1
-        ent_date = sigs.index[entry_idx]
+        ent_hold_idx = min(entry_idx + 1, n - 1)
+        ent_date = sigs.index[ent_hold_idx]
         ex_date = sigs.index[exit_idx]
         
         ent_price_a = float(p_a.iloc[entry_idx])

--- a/correlation-api/analysis/spread.py
+++ b/correlation-api/analysis/spread.py
@@ -27,7 +27,11 @@ def calculate_log_ratio_spread(series_a: pd.Series, series_b: pd.Series, hedge_r
     return log_a - hedge_ratio * log_b
 
 
+<<<<<<< HEAD
 def calculate_zscore(spread: pd.Series, window: int | None = 60) -> pd.Series:
+=======
+def calculate_zscore(spread: pd.Series, window: int = 60) -> pd.Series:
+>>>>>>> bec9def (fix look-ahead bias: add rolling window to calculate_zscore)
     """
     Calculate z-score of the spread.
     

--- a/correlation-api/analysis/spread.py
+++ b/correlation-api/analysis/spread.py
@@ -10,21 +10,21 @@ def _safe_divisor(divisor, tol=1e-12):
     return divisor.where(divisor.abs() >= tol, np.nan)
 
 
-def calculate_price_difference_spread(series_a: pd.Series, series_b: pd.Series) -> pd.Series:
+def calculate_price_difference_spread(series_a: pd.Series, series_b: pd.Series, hedge_ratio: float = 1.0) -> pd.Series:
     """Calculate simple price difference spread."""
-    return series_a - series_b
+    return series_a - hedge_ratio * series_b
 
 
-def calculate_ratio_spread(series_a: pd.Series, series_b: pd.Series) -> pd.Series:
+def calculate_ratio_spread(series_a: pd.Series, series_b: pd.Series, hedge_ratio: float = 1.0) -> pd.Series:
     """Calculate price ratio spread."""
-    return series_a / _safe_divisor(series_b)
+    return series_a / _safe_divisor(hedge_ratio * series_b)
 
 
-def calculate_log_ratio_spread(series_a: pd.Series, series_b: pd.Series) -> pd.Series:
+def calculate_log_ratio_spread(series_a: pd.Series, series_b: pd.Series, hedge_ratio: float = 1.0) -> pd.Series:
     """Calculate log price ratio spread."""
-    ratio = calculate_ratio_spread(series_a, series_b)
-    ratio = ratio.where(ratio > 0, np.nan)
-    return np.log(ratio)
+    log_a = np.log(series_a.where(series_a > 0, np.nan))
+    log_b = np.log(series_b.where(series_b > 0, np.nan))
+    return log_a - hedge_ratio * log_b
 
 
 def calculate_zscore(spread: pd.Series, window: int | None = 60) -> pd.Series:
@@ -49,7 +49,7 @@ def calculate_zscore(spread: pd.Series, window: int | None = 60) -> pd.Series:
 
 
 def calculate_spread_metrics(df: pd.DataFrame, ticker_a: str, ticker_b: str, 
-                             spread_type: str = 'log_ratio', window: int = 60) -> Tuple[pd.DataFrame, Dict]:
+                             spread_type: str = 'log_ratio', hedge_ratio: float = 1.0, window: int = 60) -> Tuple[pd.DataFrame, Dict]:
     """
     Calculate spread and basic metrics for a pair of stocks.
     
@@ -58,6 +58,7 @@ def calculate_spread_metrics(df: pd.DataFrame, ticker_a: str, ticker_b: str,
         ticker_a: First ticker symbol
         ticker_b: Second ticker symbol
         spread_type: Type of spread ('difference', 'ratio', or 'log_ratio')
+        hedge_ratio: Ratio for hedging the B ticker
         
     Returns:
         Tuple of (result DataFrame, metrics dict)
@@ -65,18 +66,18 @@ def calculate_spread_metrics(df: pd.DataFrame, ticker_a: str, ticker_b: str,
     # Extract price series and ensure they're 1D
     series_a = df[f'Close_{ticker_a}'].squeeze()
     series_b = df[f'Close_{ticker_b}'].squeeze()
-
+ 
     if isinstance(series_a, pd.DataFrame):
         series_a = pd.Series(series_a.values.flatten(), index=df.index)
     if isinstance(series_b, pd.DataFrame):
         series_b = pd.Series(series_b.values.flatten(), index=df.index)
     
     if spread_type == 'difference':
-        spread = calculate_price_difference_spread(series_a, series_b)
+        spread = calculate_price_difference_spread(series_a, series_b, hedge_ratio)
     elif spread_type == 'ratio':
-        spread = calculate_ratio_spread(series_a, series_b)
+        spread = calculate_ratio_spread(series_a, series_b, hedge_ratio)
     elif spread_type == 'log_ratio':
-        spread = calculate_log_ratio_spread(series_a, series_b)
+        spread = calculate_log_ratio_spread(series_a, series_b, hedge_ratio)
     else:
         raise ValueError(f"Unknown spread_type: {spread_type}")
     

--- a/correlation-api/analysis/spread.py
+++ b/correlation-api/analysis/spread.py
@@ -27,11 +27,7 @@ def calculate_log_ratio_spread(series_a: pd.Series, series_b: pd.Series, hedge_r
     return log_a - hedge_ratio * log_b
 
 
-<<<<<<< HEAD
 def calculate_zscore(spread: pd.Series, window: int | None = 60) -> pd.Series:
-=======
-def calculate_zscore(spread: pd.Series, window: int = 60) -> pd.Series:
->>>>>>> bec9def (fix look-ahead bias: add rolling window to calculate_zscore)
     """
     Calculate z-score of the spread.
     

--- a/correlation-api/app.py
+++ b/correlation-api/app.py
@@ -250,6 +250,7 @@ def get_backtest():
 
 
 
+
 if __name__ == "__main__":
     port = int(os.environ.get("CORRELATION_API_PORT", 5050))
     app.run(host="0.0.0.0", port=port, debug=True)

--- a/correlation-api/app.py
+++ b/correlation-api/app.py
@@ -195,9 +195,9 @@ def get_backtest():
         return jsonify({"error": "ticker_a and ticker_b are required"}), 400
 
     try:
-        window = int(request.args.get("window", "20")) #20 days
-        entry_z = float(request.args.get("entry_z", "2.0")) # spread is wide -> arbitrage!
-        exit_z = float(request.args.get("exit_z", "0.0")) # exit outta there
+        window = int(request.args.get("window", "20"))  # 20-day rolling window
+        entry_z = float(request.args.get("entry_z", "2.0"))  # z-score entry threshold
+        exit_z = float(request.args.get("exit_z", "0.0"))  # z-score exit threshold
         hedge_ratio = float(request.args.get("hedge_ratio", "1.0")) 
     except ValueError:
         return jsonify({"error": "Invalid numerical parameters"}), 400
@@ -247,8 +247,6 @@ def get_backtest():
         return jsonify(tearsheet)
     except Exception as e:
         return jsonify({"error": str(e)}), 500
-
-
 
 
 if __name__ == "__main__":

--- a/correlation-api/app.py
+++ b/correlation-api/app.py
@@ -195,10 +195,10 @@ def get_backtest():
         return jsonify({"error": "ticker_a and ticker_b are required"}), 400
 
     try:
-        window = int(request.args.get("window", "20"))
-        entry_z = float(request.args.get("entry_z", "2.0"))
-        exit_z = float(request.args.get("exit_z", "0.0"))
-        hedge_ratio = float(request.args.get("hedge_ratio", "1.0"))
+        window = int(request.args.get("window", "20")) #20 days
+        entry_z = float(request.args.get("entry_z", "2.0")) # spread is wide -> arbitrage!
+        exit_z = float(request.args.get("exit_z", "0.0")) # exit outta there
+        hedge_ratio = float(request.args.get("hedge_ratio", "1.0")) 
     except ValueError:
         return jsonify({"error": "Invalid numerical parameters"}), 400
 

--- a/correlation-api/app.py
+++ b/correlation-api/app.py
@@ -249,6 +249,7 @@ def get_backtest():
         return jsonify({"error": str(e)}), 500
 
 
+
 if __name__ == "__main__":
     port = int(os.environ.get("CORRELATION_API_PORT", 5050))
     app.run(host="0.0.0.0", port=port, debug=True)

--- a/correlation-api/app.py
+++ b/correlation-api/app.py
@@ -11,6 +11,7 @@ from analysis.data_loader import load_pair_data
 from analysis.correlation import compute_lagged_correlation
 from analysis.spread import calculate_spread_metrics
 from analysis.risk import detect_correlation_breakdown
+from analysis.backtest import generate_zscore_signals, run_backtest
 
 app = Flask(__name__)
 CORS(app)
@@ -178,6 +179,72 @@ def get_risk_breakdown():
         })
     except ValueError as e:
         return jsonify({"error": str(e)}), 400
+    except Exception as e:
+        return jsonify({"error": str(e)}), 500
+
+
+@app.route("/api/backtest", methods=["GET"])
+def get_backtest():
+    ticker_a = request.args.get("ticker_a", "").upper()
+    ticker_b = request.args.get("ticker_b", "").upper()
+    start = request.args.get("start", "2023-01-01")
+    end = request.args.get("end", str(date.today()))
+    spread_type = request.args.get("spread_type", "log_ratio")
+
+    if not ticker_a or not ticker_b:
+        return jsonify({"error": "ticker_a and ticker_b are required"}), 400
+
+    try:
+        window = int(request.args.get("window", "20"))
+        entry_z = float(request.args.get("entry_z", "2.0"))
+        exit_z = float(request.args.get("exit_z", "0.0"))
+        hedge_ratio = float(request.args.get("hedge_ratio", "1.0"))
+    except ValueError:
+        return jsonify({"error": "Invalid numerical parameters"}), 400
+
+    try:
+        df = load_pair_data(ticker_a, ticker_b, start, end)
+        if len(df) == 0:
+            return jsonify({"error": "No data found for the given tickers and date range"}), 400
+
+        spread_df, _ = calculate_spread_metrics(df, ticker_a, ticker_b, spread_type)
+        
+        spread_df = spread_df.set_index(pd.to_datetime(spread_df["Date"]))
+
+        prices_a = spread_df[f"{ticker_a}_price"]
+        prices_b = spread_df[f"{ticker_b}_price"]
+        spread_series = spread_df["spread"]
+
+        # Generate rolling z-score and walk-forward signals
+        signals, rolling_zscore = generate_zscore_signals(
+            spread_series,
+            window=window,
+            entry_z=entry_z,
+            exit_z=exit_z
+        )
+
+        # Run backtest
+        results = run_backtest(prices_a, prices_b, signals, hedge_ratio)
+
+        tearsheet = {
+            "ticker_a": ticker_a,
+            "ticker_b": ticker_b,
+            "window": window,
+            "entry_z": entry_z,
+            "exit_z": exit_z,
+            "hedge_ratio": hedge_ratio,
+            "spread_type": spread_type,
+            "metrics": {
+                "sharpe": _safe_float(results["sharpe"]),
+                "max_drawdown": _safe_float(results["max_dd"]),
+                "num_trades": int(results["num_trades"]),
+                "win_rate": _safe_float(results["win_rate"]),
+            },
+            "equity_curve": results["equity_curve"],
+            "trade_log": results["trade_log"]
+        }
+
+        return jsonify(tearsheet)
     except Exception as e:
         return jsonify({"error": str(e)}), 500
 

--- a/correlation-api/app.py
+++ b/correlation-api/app.py
@@ -207,7 +207,7 @@ def get_backtest():
         if len(df) == 0:
             return jsonify({"error": "No data found for the given tickers and date range"}), 400
 
-        spread_df, _ = calculate_spread_metrics(df, ticker_a, ticker_b, spread_type)
+        spread_df, _ = calculate_spread_metrics(df, ticker_a, ticker_b, spread_type, hedge_ratio)
         
         spread_df = spread_df.set_index(pd.to_datetime(spread_df["Date"]))
 

--- a/correlation-api/requirements.txt
+++ b/correlation-api/requirements.txt
@@ -1,0 +1,6 @@
+flask>=3.0.0
+flask-cors>=4.0.0
+gunicorn>=21.0.0
+yfinance>=0.2.40
+pandas>=2.0.0
+numpy>=1.24.0

--- a/correlation-api/requirements.txt
+++ b/correlation-api/requirements.txt
@@ -1,6 +1,0 @@
-flask>=3.0.0
-flask-cors>=4.0.0
-gunicorn>=21.0.0
-yfinance>=0.2.40
-pandas>=2.0.0
-numpy>=1.24.0

--- a/correlation-api/test_backtest.py
+++ b/correlation-api/test_backtest.py
@@ -1,7 +1,6 @@
 import os
 import unittest
 import pandas as pd
-import requests
 from analysis.backtest import generate_zscore_signals, run_backtest
 
 class TestBacktestHarness(unittest.TestCase):
@@ -64,37 +63,45 @@ class TestBacktestHarness(unittest.TestCase):
         self.assertEqual(len(zscore), len(self.spread))
 
     def test_api_integration(self):
-        # Call the live endpoint (since our server is running in the background)
-        url = "http://localhost:5050/api/backtest"
-        params = {
-            "ticker_a": "MSFT",
-            "ticker_b": "GOOGL",
-            "window": 20,
-            "entry_z": 2.0,
-            "exit_z": 0.0,
-            "start": "2023-01-01"
-        }
-        try:
-            resp = requests.get(url, params=params)
-            self.assertEqual(resp.status_code, 200)
-            data = resp.json()
-            
-            # Check fields
-            self.assertEqual(data["ticker_a"], "MSFT")
-            self.assertEqual(data["ticker_b"], "GOOGL")
-            self.assertIn("metrics", data)
-            self.assertIn("equity_curve", data)
-            self.assertIn("trade_log", data)
-            
-            metrics = data["metrics"]
-            self.assertIn("sharpe", metrics)
-            self.assertIn("max_drawdown", metrics)
-            self.assertIn("num_trades", metrics)
-            self.assertIn("win_rate", metrics)
-            
-            print(f"\n[API TEST SUCCESS] Sharpe: {metrics['sharpe']:.4f}, Max DD: {metrics['max_drawdown']:.4f}, Trades: {metrics['num_trades']}, Win Rate: {metrics['win_rate']:.4%}")
-        except requests.exceptions.ConnectionError:
-            self.fail("Flask API server is not running on http://localhost:5050")
+        from unittest.mock import patch
+        from app import app
+        import pandas as pd
+        import numpy as np
+        
+        # Create synthetic DataFrame matching load_pair_data output schema
+        dates = pd.date_range(start="2023-01-01", periods=100)
+        # MSFT oscillates, GOOGL is flat at 100.0 to generate spread fluctuations
+        prices_msft = 100.0 + 5.0 * np.sin(np.arange(100) / 3.0)
+        prices_googl = [100.0] * 100
+        mock_df = pd.DataFrame({
+            "Date": dates,
+            "Close_MSFT": prices_msft,
+            "Ticker_MSFT": ["MSFT"] * 100,
+            "Close_GOOGL": prices_googl,
+            "Ticker_GOOGL": ["GOOGL"] * 100
+        })
+        
+        with patch("app.load_pair_data") as mock_load:
+            mock_load.return_value = mock_df
+            with app.test_client() as client:
+                resp = client.get("/api/backtest?ticker_a=MSFT&ticker_b=GOOGL&window=20&entry_z=1.0&exit_z=0.0")
+                self.assertEqual(resp.status_code, 200)
+                data = resp.get_json()
+                
+                # Check fields
+                self.assertEqual(data["ticker_a"], "MSFT")
+                self.assertEqual(data["ticker_b"], "GOOGL")
+                self.assertIn("metrics", data)
+                self.assertIn("equity_curve", data)
+                self.assertIn("trade_log", data)
+                
+                metrics = data["metrics"]
+                self.assertIn("sharpe", metrics)
+                self.assertIn("max_drawdown", metrics)
+                self.assertIn("num_trades", metrics)
+                self.assertIn("win_rate", metrics)
+                
+                print(f"\n[API MOCK TEST SUCCESS] Sharpe: {metrics['sharpe']:.4f}, Max DD: {metrics['max_drawdown']:.4f}, Trades: {metrics['num_trades']}, Win Rate: {metrics['win_rate']:.4%}")
 
 if __name__ == "__main__":
     unittest.main()

--- a/correlation-api/test_backtest.py
+++ b/correlation-api/test_backtest.py
@@ -85,7 +85,6 @@ class TestBacktestHarness(unittest.TestCase):
             self.assertIn("metrics", data)
             self.assertIn("equity_curve", data)
             self.assertIn("trade_log", data)
-            self.assertIn("detailed_data", data)
             
             metrics = data["metrics"]
             self.assertIn("sharpe", metrics)

--- a/correlation-api/test_backtest.py
+++ b/correlation-api/test_backtest.py
@@ -1,0 +1,101 @@
+import unittest
+import pandas as pd
+import numpy as np
+import requests
+from analysis.backtest import generate_zscore_signals, run_backtest
+
+class TestBacktestHarness(unittest.TestCase):
+    def setUp(self):
+        # Create a simple 10-day synthetic price series
+        # Day:         0     1     2     3     4     5     6     7     8     9
+        # Price A:   100   102   104   102   100    98    96    98   100   102
+        # Price B:   100   100   100   100   100   100   100   100   100   100
+        # Spread:      0     2     4     2     0    -2    -4    -2     0     2
+        dates = pd.date_range(start="2026-05-01", periods=10)
+        self.prices_a = pd.Series([100.0, 102.0, 104.0, 102.0, 100.0, 98.0, 96.0, 98.0, 100.0, 102.0], index=dates)
+        self.prices_b = pd.Series([100.0] * 10, index=dates)
+        self.spread = self.prices_a - self.prices_b
+        
+        # Test signal sequence:
+        # Day 0: 0
+        # Day 1: 0
+        # Day 2: -1 (Short spread - Short A, Long B)
+        # Day 3: -1
+        # Day 4: 0  (Closed trade - Flat)
+        # Day 5: 1  (Long spread - Long A, Short B)
+        # Day 6: 1
+        # Day 7: 0  (Closed trade - Flat)
+        # Day 8: 0
+        # Day 9: 0
+        self.signals = pd.Series([0, 0, -1, -1, 0, 1, 1, 0, 0, 0], index=dates)
+
+    def test_run_backtest_metrics(self):
+        # Run the backtester
+        results = run_backtest(self.prices_a, self.prices_b, self.signals, hedge_ratio=1.0)
+        
+        self.assertIn("equity_curve", results)
+        self.assertIn("sharpe", results)
+        self.assertIn("max_dd", results)
+        self.assertIn("num_trades", results)
+        self.assertIn("win_rate", results)
+        self.assertIn("trade_log", results)
+        
+        # We had 2 trades completed:
+        # Trade 1: Short spread entered at index 2 (price_a=104, price_b=100, spread=4)
+        #          Closed at index 4 (price_a=100, price_b=100, spread=0)
+        #          For short: spread_entry (4) - spread_exit (0) = +4 P&L. Profit!
+        # Trade 2: Long spread entered at index 5 (price_a=98, price_b=100, spread=-2)
+        #          Closed at index 7 (price_a=98, price_b=100, spread=-2)
+        #          For long: spread_exit (-2) - spread_entry (-2) = 0 P&L. Flat!
+        self.assertEqual(results["num_trades"], 2)
+        
+        trade1 = results["trade_log"][0]
+        self.assertEqual(trade1["type"], "SHORT")
+        self.assertEqual(trade1["pnl_val"], 4.0)
+        
+        trade2 = results["trade_log"][1]
+        self.assertEqual(trade2["type"], "LONG")
+        self.assertEqual(trade2["pnl_val"], 0.0)
+
+    def test_generate_zscore_signals(self):
+        # Verify signal generator doesn't crash and returns signals and zscore
+        signals, zscore = generate_zscore_signals(self.spread, window=5, entry_z=1.0, exit_z=0.0)
+        self.assertEqual(len(signals), len(self.spread))
+        self.assertEqual(len(zscore), len(self.spread))
+
+    def test_api_integration(self):
+        # Call the live endpoint (since our server is running in the background)
+        url = "http://localhost:5050/api/backtest"
+        params = {
+            "ticker_a": "MSFT",
+            "ticker_b": "GOOGL",
+            "window": 20,
+            "entry_z": 2.0,
+            "exit_z": 0.0,
+            "start": "2023-01-01"
+        }
+        try:
+            resp = requests.get(url, params=params)
+            self.assertEqual(resp.status_code, 200)
+            data = resp.json()
+            
+            # Check fields
+            self.assertEqual(data["ticker_a"], "MSFT")
+            self.assertEqual(data["ticker_b"], "GOOGL")
+            self.assertIn("metrics", data)
+            self.assertIn("equity_curve", data)
+            self.assertIn("trade_log", data)
+            self.assertIn("detailed_data", data)
+            
+            metrics = data["metrics"]
+            self.assertIn("sharpe", metrics)
+            self.assertIn("max_drawdown", metrics)
+            self.assertIn("num_trades", metrics)
+            self.assertIn("win_rate", metrics)
+            
+            print(f"\n[API TEST SUCCESS] Sharpe: {metrics['sharpe']:.4f}, Max DD: {metrics['max_drawdown']:.4f}, Trades: {metrics['num_trades']}, Win Rate: {metrics['win_rate']:.4%}")
+        except requests.exceptions.ConnectionError:
+            self.fail("Flask API server is not running on http://localhost:5050")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/correlation-api/test_backtest.py
+++ b/correlation-api/test_backtest.py
@@ -1,6 +1,6 @@
+import os
 import unittest
 import pandas as pd
-import numpy as np
 import requests
 from analysis.backtest import generate_zscore_signals, run_backtest
 


### PR DESCRIPTION
## Background

Backtesting lets us see how our strategy would perform in the past. This lets us get a sense of how good the strategy is for trading (even though markets are non-stationary processes).

Closes #8 

**Note: there are no frontend changes associated with this PR. Endpoint cannot be accessed through the clubsite yet.**

## Summary
- Added `correlation-api/analysis/backtest.py` which has the backtesting engine
This mostly includes methods `generate_zscore_signals` whichs calcualtes rolling z-scores of the spread without any lookahead, and `run_backtest` which computes daily P&L + percentage returns, and cumulative returns.
- Added `GET /api/backtest` in `app.py` which takes in parameters:
- `ticker_a`, `ticker_b`, `window`, `entry_z`, `exit_z`, `hedge_ratio`, and `spread_type`.
This endpoint performs the walk-forward signal generator, performs the backtest using the strategy that the parameter describes, and outputs the JSON Tearsheet with summary metrics, equity curve, and a trade ledger
- Added `correlation-api/test_backtest.py` because my agent did it

## How to run

1. Start the Flask backend:
   ```bash
   cd correlation-api
   python3 app.py
   ```

2. Start the Next app frontend (in another terminal):
   ```bash
   npm install
   npm run dev
   ```

3. Hit the endpoint using your browser or `curl` it to verify the JSON tearsheet is being returned:
```bash
curl "http://localhost:5050/api/backtest?ticker_a=MSFT&ticker_b=GOOGL"
```
Output should look like this:
```
{
"ticker_a",
"ticker_b",
"window",
"entry_z",
"exit_z",
"hedge_ratio",
"spread_type",
"metrics": {
    "sharpe",
    "max_drawdown",
    "num_trades",
    "win_rate",
},
"equity_curve",
"trade_log"
}
```
Just note that `equity_curve` and `trade_log` will be a very long list of `JSON` elements.