### PR TITLE
Redirect correlation trading to standalone app

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,6 +2,15 @@
 const apiBase = process.env.CORRELATION_API_URL || "http://localhost:5050";
 
 const nextConfig = {
+  async redirects() {
+    return [
+      {
+        source: "/correlation-trading",
+        destination: "https://correlation-trading.onrender.com",
+        permanent: false,
+      },
+    ];
+  },
   async rewrites() {
     return [
       {


### PR DESCRIPTION
## Summary
- redirect /correlation-trading to the standalone Render deployment
- use a temporary 307 redirect during the dual-run validation period
- keep the existing clubsite implementation and API in place for rollback

## Verification
- npm ci
- npm run build
- git diff --check

The production build compiled and generated its build artifact. It continues to emit the existing Next.js/ESLint invalid-options warning from the current dependency versions.